### PR TITLE
Add next question navigation control

### DIFF
--- a/styles/digitalSafetyQuiz.css
+++ b/styles/digitalSafetyQuiz.css
@@ -195,6 +195,14 @@
   box-shadow: 0 12px 24px rgba(59, 130, 246, 0.3);
 }
 
+.dsq-button:disabled,
+.dsq-button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
 .dsq-button:focus {
   outline: 3px solid rgba(99, 102, 241, 0.4);
   outline-offset: 2px;


### PR DESCRIPTION
## Summary
- add an explicit "Volgende vraag" control so players can advance after checking their answer
- prevent accidental skipping by keeping the next button disabled until the correct answer is given
- style disabled buttons and improve feedback messaging when no answer is selected

## Testing
- Manual verification in the browser

------
https://chatgpt.com/codex/tasks/task_e_68e0f35b20188323ba88486c925fe2cf