### PR TITLE
Move live dashboard to standalone dashboard page

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Live quizdashboard</title>
+    <link rel="stylesheet" href="../styles/digitalSafetyQuiz.css" />
+  </head>
+  <body class="dsq-dashboard-page">
+    <div class="dsq-dashboard-wrapper">
+      <section id="dashboard" class="dsq-card"></section>
+    </div>
+
+    <script src="../src/digitalSafetyQuiz.js"></script>
+    <script src="../src/quizDashboard.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        createDigitalSafetyDashboard({ container: "#dashboard" });
+      });
+    </script>
+  </body>
+</html>

--- a/src/digitalSafetyQuiz.js
+++ b/src/digitalSafetyQuiz.js
@@ -157,6 +157,374 @@
     return el;
   }
 
+  function storageAvailable(type = "localStorage") {
+    if (typeof window === "undefined") {
+      return false;
+    }
+
+    try {
+      const storage = window[type];
+      const testKey = "__dsq_storage_test__";
+      storage.setItem(testKey, testKey);
+      storage.removeItem(testKey);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function generateId(prefix = "id") {
+    const basePrefix = prefix ? `${prefix}-` : "";
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+      return `${basePrefix}${crypto.randomUUID()}`;
+    }
+    const randomPart = Math.random().toString(36).slice(2);
+    return `${basePrefix}${Date.now().toString(36)}-${randomPart}`;
+  }
+
+  const SESSION_EVENT_NAME = "dsq:sessions-updated";
+
+  class DailySessionStore {
+    constructor(options = {}) {
+      this.prefix = options.prefix || "digitalSafetyQuiz:sessions";
+      this.storageEnabled = storageAvailable("localStorage");
+      this.memoryStore = {};
+      this.sessionIndex = {};
+      this._rebuildIndex();
+    }
+
+    _getDateKey(date = new Date()) {
+      return `${this.prefix}:${date.toISOString().slice(0, 10)}`;
+    }
+
+    _readByKey(dateKey) {
+      if (!dateKey) {
+        return { sessions: [] };
+      }
+
+      if (this.storageEnabled) {
+        const raw = window.localStorage.getItem(dateKey);
+        if (!raw) {
+          return { sessions: [] };
+        }
+        try {
+          return JSON.parse(raw);
+        } catch (error) {
+          return { sessions: [] };
+        }
+      }
+
+      if (!this.memoryStore[dateKey]) {
+        this.memoryStore[dateKey] = { sessions: [] };
+      }
+
+      return JSON.parse(JSON.stringify(this.memoryStore[dateKey]));
+    }
+
+    _saveByKey(dateKey, data) {
+      const serialized = JSON.stringify(data);
+      if (this.storageEnabled) {
+        window.localStorage.setItem(dateKey, serialized);
+      } else {
+        this.memoryStore[dateKey] = JSON.parse(serialized);
+      }
+      this._indexSessions(dateKey, data.sessions);
+      this._broadcastChange();
+    }
+
+    _indexSessions(dateKey, sessions = []) {
+      sessions.forEach((session) => {
+        if (session && session.id) {
+          this.sessionIndex[session.id] = dateKey;
+        }
+      });
+    }
+
+    _rebuildIndex() {
+      const todayKey = this._getDateKey();
+      const data = this._readByKey(todayKey);
+      this._indexSessions(todayKey, data.sessions);
+    }
+
+    _getSession(dateKey, sessionId) {
+      const data = this._readByKey(dateKey);
+      const session = data.sessions.find((entry) => entry.id === sessionId);
+      return { data, session };
+    }
+
+    _broadcastChange() {
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent(SESSION_EVENT_NAME));
+      }
+    }
+
+    createSession(name) {
+      const now = new Date();
+      const dateKey = this._getDateKey(now);
+      const data = this._readByKey(dateKey);
+      const session = {
+        id: generateId("session"),
+        dateKey,
+        name,
+        startTime: now.toISOString(),
+        status: "active",
+        attempts: [],
+        stats: { correct: 0, incorrect: 0 },
+        summary: null,
+        lastUpdated: now.toISOString()
+      };
+
+      data.sessions.push(session);
+      this._saveByKey(dateKey, data);
+      return session;
+    }
+
+    recordAttempt(sessionId, attempt) {
+      if (!sessionId) {
+        return null;
+      }
+
+      const dateKey = this.sessionIndex[sessionId] || this._getDateKey();
+      const { data, session } = this._getSession(dateKey, sessionId);
+      if (!session) {
+        return null;
+      }
+
+      if (!Array.isArray(session.attempts)) {
+        session.attempts = [];
+      }
+      session.attempts.push({ ...attempt });
+
+      session.stats = session.stats || { correct: 0, incorrect: 0 };
+      if (attempt.isCorrect) {
+        session.stats.correct += 1;
+      } else {
+        session.stats.incorrect += 1;
+      }
+
+      session.lastUpdated = new Date().toISOString();
+      this._saveByKey(dateKey, data);
+      return session;
+    }
+
+    completeSession(sessionId, summary) {
+      if (!sessionId) {
+        return null;
+      }
+
+      const dateKey = this.sessionIndex[sessionId] || this._getDateKey();
+      const { data, session } = this._getSession(dateKey, sessionId);
+      if (!session) {
+        return null;
+      }
+
+      session.status = "completed";
+      session.summary = summary;
+      session.endTime = new Date().toISOString();
+      session.lastUpdated = session.endTime;
+
+      this._saveByKey(dateKey, data);
+      return session;
+    }
+
+    getSnapshot() {
+      const todayKey = this._getDateKey();
+      const data = this._readByKey(todayKey);
+      const activeSessions = data.sessions.filter(
+        (session) => session.status === "active"
+      );
+
+      const totals = data.sessions.reduce(
+        (acc, session) => {
+          const stats = session.stats || { correct: 0, incorrect: 0 };
+          acc.correct += stats.correct;
+          acc.incorrect += stats.incorrect;
+          if (session.status === "active") {
+            acc.activeParticipants += 1;
+          }
+          return acc;
+        },
+        { correct: 0, incorrect: 0, activeParticipants: 0 }
+      );
+
+      return {
+        dateKey: todayKey,
+        totals,
+        activeSessions: activeSessions.map((session) => ({
+          id: session.id,
+          name: session.name,
+          correct: session.stats?.correct || 0,
+          incorrect: session.stats?.incorrect || 0,
+          startTime: session.startTime
+        })),
+        totalSessions: data.sessions.length
+      };
+    }
+  }
+
+  class DashboardView {
+    constructor(container, store) {
+      this.container = container;
+      this.store = store;
+      this.elements = {};
+      this.render();
+      this.update();
+
+      this.handleUpdate = this.update.bind(this);
+      if (typeof window !== "undefined") {
+        window.addEventListener(SESSION_EVENT_NAME, this.handleUpdate);
+        window.addEventListener("storage", this.handleUpdate);
+      }
+    }
+
+    render() {
+      this.container.innerHTML = "";
+      this.container.classList.add("dsq-dashboard");
+
+      const title = createElement("h2", {
+        className: "dsq-dashboard-title",
+        text: "Live dashboard"
+      });
+      const dateEl = createElement("p", {
+        className: "dsq-dashboard-date"
+      });
+
+      const metricsWrapper = createElement("div", {
+        className: "dsq-dashboard-metrics"
+      });
+
+      const participantMetric = this._createMetric(
+        "Actieve deelnemers",
+        "0"
+      );
+      const correctMetric = this._createMetric("Goede antwoorden", "0");
+      const incorrectMetric = this._createMetric("Foute antwoorden", "0");
+
+      metricsWrapper.append(
+        participantMetric.wrapper,
+        correctMetric.wrapper,
+        incorrectMetric.wrapper
+      );
+
+      const sessionTitle = createElement("h3", {
+        className: "dsq-dashboard-subtitle",
+        text: "Actieve sessies"
+      });
+      const sessionList = createElement("ul", {
+        className: "dsq-dashboard-session-list"
+      });
+
+      this.container.append(title, dateEl, metricsWrapper, sessionTitle, sessionList);
+
+      this.elements.date = dateEl;
+      this.elements.participants = participantMetric.valueEl;
+      this.elements.correct = correctMetric.valueEl;
+      this.elements.incorrect = incorrectMetric.valueEl;
+      this.elements.sessionList = sessionList;
+    }
+
+    _createMetric(label, value) {
+      const wrapper = createElement("div", {
+        className: "dsq-dashboard-metric"
+      });
+      const valueEl = createElement("span", {
+        className: "dsq-dashboard-metric-value",
+        text: value
+      });
+      const labelEl = createElement("span", {
+        className: "dsq-dashboard-metric-label",
+        text: label
+      });
+      wrapper.append(valueEl, labelEl);
+      return { wrapper, valueEl, labelEl };
+    }
+
+    update() {
+      if (!this.store) {
+        return;
+      }
+
+      const snapshot = this.store.getSnapshot();
+      const dateKey = snapshot.dateKey.split(":").pop();
+      this.elements.date.textContent = `Vandaag: ${this._formatDate(dateKey)}`;
+      this.elements.participants.textContent = String(
+        snapshot.totals.activeParticipants || 0
+      );
+      this.elements.correct.textContent = String(snapshot.totals.correct || 0);
+      this.elements.incorrect.textContent = String(
+        snapshot.totals.incorrect || 0
+      );
+
+      this._renderSessions(snapshot.activeSessions);
+    }
+
+    _renderSessions(sessions = []) {
+      const list = this.elements.sessionList;
+      list.innerHTML = "";
+
+      if (!sessions.length) {
+        list.append(
+          createElement("li", {
+            className: "dsq-dashboard-session-empty",
+            text: "Geen actieve sessies"
+          })
+        );
+        return;
+      }
+
+      sessions.forEach((session) => {
+        const item = createElement("li", {
+          className: "dsq-dashboard-session-item"
+        });
+
+        const nameEl = createElement("span", {
+          className: "dsq-dashboard-session-name",
+          text: session.name || "Onbekend"
+        });
+        const statsEl = createElement("span", {
+          className: "dsq-dashboard-session-stats",
+          text: `${session.correct} goed • ${session.incorrect} fout`
+        });
+        const timeEl = createElement("span", {
+          className: "dsq-dashboard-session-time",
+          text: `Gestart om ${this._formatTime(session.startTime)}`
+        });
+
+        item.append(nameEl, statsEl, timeEl);
+        list.append(item);
+      });
+    }
+
+    _formatDate(dateString) {
+      if (!dateString) {
+        return "-";
+      }
+      const [year, month, day] = dateString.split("-");
+      return `${day}-${month}-${year}`;
+    }
+
+    _formatTime(timeString) {
+      if (!timeString) {
+        return "--:--";
+      }
+      const date = new Date(timeString);
+      if (Number.isNaN(date.getTime())) {
+        return "--:--";
+      }
+      return date.toLocaleTimeString("nl-NL", {
+        hour: "2-digit",
+        minute: "2-digit"
+      });
+    }
+
+    destroy() {
+      if (typeof window !== "undefined") {
+        window.removeEventListener(SESSION_EVENT_NAME, this.handleUpdate);
+        window.removeEventListener("storage", this.handleUpdate);
+      }
+    }
+  }
+
   function normalizeConfig(userConfig = {}) {
     const config = JSON.parse(JSON.stringify(defaultConfig));
     if (!userConfig) {
@@ -187,6 +555,11 @@
           "DigitalSafetyQuiz: kon de container niet vinden. Geef een element of CSS-selector door."
         );
       }
+      this.sessionStore = new DailySessionStore();
+      this.sessionId = null;
+      this.sessionResults = new Map();
+      this.participantName = "";
+      this.sessionCompleted = false;
       this.currentModuleIndex = -1;
       this.currentQuestionIndex = -1;
       this.score = 0;
@@ -225,6 +598,10 @@
     renderIntro() {
       this.mainEl.innerHTML = "";
       this.footerEl.innerHTML = "";
+      this.sessionId = null;
+      this.sessionResults = new Map();
+      this.participantName = "";
+      this.sessionCompleted = false;
 
       const introCard = createElement("section", {
         className: "dsq-card dsq-intro"
@@ -236,20 +613,66 @@
         })
       );
 
+      const nameField = createElement("div", {
+        className: "dsq-input-group"
+      });
+      const nameLabel = createElement("label", {
+        className: "dsq-label",
+        text: "Wat is je naam?",
+        attrs: { for: "dsq-participant-name" }
+      });
+      const nameInput = createElement("input", {
+        attrs: {
+          id: "dsq-participant-name",
+          type: "text",
+          placeholder: this.config.strings.enterName,
+          "aria-label": this.config.strings.enterName,
+          autocomplete: "name"
+        },
+        className: "dsq-input"
+      });
+      nameField.append(nameLabel, nameInput);
+
       const startButton = createElement("button", {
         className: "dsq-button",
         text: this.config.strings.startButton
       });
+      startButton.disabled = true;
+
+      const updateStartButton = () => {
+        const hasName = nameInput.value.trim().length > 0;
+        startButton.disabled = !hasName;
+      };
+
+      nameInput.addEventListener("input", updateStartButton);
       startButton.addEventListener("click", () => {
-        this.startQuiz();
+        const name = nameInput.value.trim();
+        if (!name) {
+          return;
+        }
+        startButton.disabled = true;
+        this.startQuiz(name);
       });
 
-      introCard.append(startButton);
+      introCard.append(nameField, startButton);
       this.mainEl.append(introCard);
       this.updateProgress();
     }
 
-    startQuiz() {
+    startQuiz(name) {
+      if (this.sessionId) {
+        return;
+      }
+      this.participantName = (name || "").trim();
+      if (!this.participantName) {
+        return;
+      }
+
+      this.sessionResults = new Map();
+      this.sessionCompleted = false;
+      const session = this.sessionStore.createSession(this.participantName);
+      this.sessionId = session?.id || null;
+
       this.currentModuleIndex = 0;
       this.currentQuestionIndex = -1;
       this.score = 0;
@@ -361,26 +784,53 @@
 
       form.addEventListener("submit", (event) => {
         event.preventDefault();
+        if (form.classList.contains("dsq-question-locked")) {
+          return;
+        }
+
         const answers = Array.from(
           form.querySelectorAll("input:checked")
         ).map((input) => input.value);
 
+        if (!answers.length) {
+          feedbackEl.textContent =
+            question.type === "multiple"
+              ? this.config.strings.selectMultiple
+              : this.config.strings.selectOptions;
+          feedbackEl.classList.remove(
+            "dsq-feedback-correct",
+            "dsq-feedback-incorrect"
+          );
+          feedbackEl.classList.add("dsq-feedback-incorrect");
+          return;
+        }
+
         const isCorrect = this.evaluateAnswer(question, answers);
+        this.handleQuestionAttempt(module, question, answers, isCorrect);
+
         if (isCorrect) {
           this.score += 1;
-          feedbackEl.textContent = question.feedback?.correct || this.config.strings.feedbackCorrect;
-          feedbackEl.classList.remove("dsq-feedback-incorrect");
-          feedbackEl.classList.add("dsq-feedback-correct");
-
-          setTimeout(() => {
-            this.currentQuestionIndex += 1;
-            this.renderQuestion();
-          }, 1000);
-        } else {
-          feedbackEl.textContent = question.feedback?.incorrect || this.config.strings.feedbackIncorrect;
-          feedbackEl.classList.remove("dsq-feedback-correct");
-          feedbackEl.classList.add("dsq-feedback-incorrect");
         }
+
+        form.classList.add("dsq-question-locked");
+        button.disabled = true;
+        form.querySelectorAll("input").forEach((input) => {
+          input.disabled = true;
+        });
+
+        feedbackEl.textContent = isCorrect
+          ? question.feedback?.correct || this.config.strings.feedbackCorrect
+          : question.feedback?.incorrect || this.config.strings.feedbackIncorrect;
+
+        feedbackEl.classList.remove("dsq-feedback-correct", "dsq-feedback-incorrect");
+        feedbackEl.classList.add(
+          isCorrect ? "dsq-feedback-correct" : "dsq-feedback-incorrect"
+        );
+
+        setTimeout(() => {
+          this.currentQuestionIndex += 1;
+          this.renderQuestion();
+        }, 1200);
       });
 
       questionCard.append(form, feedbackEl);
@@ -388,6 +838,93 @@
       this.footerEl.innerHTML = "";
 
       this.updateProgress();
+    }
+
+    handleQuestionAttempt(module, question, answers, isCorrect) {
+      if (!this.sessionResults) {
+        this.sessionResults = new Map();
+      }
+
+      const attemptRecord = this._createAttemptRecord(
+        module,
+        question,
+        answers,
+        isCorrect
+      );
+
+      this._updateSessionResults(module, question, attemptRecord);
+
+      if (this.sessionStore && this.sessionId) {
+        this.sessionStore.recordAttempt(this.sessionId, attemptRecord);
+      }
+
+      return attemptRecord;
+    }
+
+    _getAttemptCount(moduleId, questionId) {
+      const moduleResult = this.sessionResults.get(moduleId);
+      if (!moduleResult) {
+        return 0;
+      }
+      const questionResult = moduleResult.questions.get(questionId);
+      return questionResult ? questionResult.attempts.length : 0;
+    }
+
+    _createAttemptRecord(module, question, answers, isCorrect) {
+      const attemptNumber =
+        this._getAttemptCount(module.id, question.id) + 1;
+      const timestamp = new Date().toISOString();
+      const answerLabels = answers.map((answerId) => {
+        const option = question.options.find((opt) => opt.id === answerId);
+        return option ? option.label : answerId;
+      });
+
+      return {
+        id: generateId("attempt"),
+        moduleId: module.id,
+        moduleTitle: module.title,
+        questionId: question.id,
+        questionText: question.text,
+        selectedAnswers: [...answers],
+        selectedAnswerLabels: answerLabels,
+        isCorrect,
+        attemptNumber,
+        timestamp
+      };
+    }
+
+    _updateSessionResults(module, question, attemptRecord) {
+      let moduleResult = this.sessionResults.get(module.id);
+      if (!moduleResult) {
+        moduleResult = {
+          moduleId: module.id,
+          moduleTitle: module.title,
+          questions: new Map()
+        };
+        this.sessionResults.set(module.id, moduleResult);
+      }
+
+      let questionResult = moduleResult.questions.get(question.id);
+      if (!questionResult) {
+        questionResult = {
+          questionId: question.id,
+          questionText: question.text,
+          attempts: []
+        };
+        moduleResult.questions.set(question.id, questionResult);
+      }
+
+      questionResult.attempts.push({
+        attemptNumber: attemptRecord.attemptNumber,
+        selectedAnswers: [...attemptRecord.selectedAnswers],
+        selectedAnswerLabels: [...attemptRecord.selectedAnswerLabels],
+        isCorrect: attemptRecord.isCorrect,
+        timestamp: attemptRecord.timestamp
+      });
+
+      questionResult.finalCorrect = attemptRecord.isCorrect;
+      questionResult.finalAnswers = [...attemptRecord.selectedAnswers];
+      questionResult.finalAnswerLabels = [...attemptRecord.selectedAnswerLabels];
     }
 
     evaluateAnswer(question, answers) {
@@ -438,6 +975,15 @@
       this.mainEl.innerHTML = "";
       this.footerEl.innerHTML = "";
 
+      const summary = this.getCompletionSummary();
+      if (!this.sessionCompleted && this.sessionStore && this.sessionId) {
+        this.sessionStore.completeSession(this.sessionId, summary);
+        this.sessionCompleted = true;
+      }
+
+      const summaryCard = this.buildSummaryCard(summary);
+      this.mainEl.append(summaryCard);
+
       const certificateCard = createElement("section", {
         className: "dsq-card dsq-certificate"
       });
@@ -455,6 +1001,7 @@
         },
         className: "dsq-input"
       });
+      nameInput.value = this.participantName;
 
       const certificatePreview = createElement("div", {
         className: "dsq-certificate-preview"
@@ -494,6 +1041,109 @@
       certificateCard.append(nameInput, certificatePreview, downloadButton, resetButton);
       this.mainEl.append(certificateCard);
       this.updateProgress(true);
+    }
+
+    getCompletionSummary() {
+      const modules = this.config.modules.map((module) => {
+        const moduleResult = this.sessionResults.get(module.id);
+        const questions = module.questions.map((question) => {
+          const questionResult = moduleResult?.questions?.get
+            ? moduleResult.questions.get(question.id)
+            : undefined;
+          const attempts = questionResult?.attempts?.map((attempt) => ({
+            attemptNumber: attempt.attemptNumber,
+            selectedAnswers: [...attempt.selectedAnswers],
+            selectedAnswerLabels: [...attempt.selectedAnswerLabels],
+            isCorrect: attempt.isCorrect,
+            timestamp: attempt.timestamp
+          })) || [];
+
+          return {
+            questionId: question.id,
+            questionText: question.text,
+            finalCorrect: Boolean(questionResult?.finalCorrect),
+            finalAnswerLabels: questionResult?.finalAnswerLabels || [],
+            attempts
+          };
+        });
+
+        return {
+          moduleId: module.id,
+          moduleTitle: module.title,
+          questions
+        };
+      });
+
+      return {
+        participant: this.participantName,
+        score: this.score,
+        totalQuestions: this.totalQuestions,
+        modules
+      };
+    }
+
+    buildSummaryCard(summary) {
+      const summaryCard = createElement("section", {
+        className: "dsq-card dsq-summary-card"
+      });
+
+      summaryCard.append(
+        createElement("h2", { text: "Jouw resultaten" }),
+        createElement("p", {
+          className: "dsq-summary-intro",
+          text: "Bekijk welke vragen je goed of fout hebt beantwoord."
+        }),
+        createElement("p", {
+          className: "dsq-summary-score",
+          text: `Score: ${summary.score}/${summary.totalQuestions}`
+        })
+      );
+
+      summary.modules.forEach((moduleSummary) => {
+        const moduleEl = createElement("div", {
+          className: "dsq-summary-module"
+        });
+        moduleEl.append(
+          createElement("h3", { text: moduleSummary.moduleTitle })
+        );
+
+        const list = createElement("ul", {
+          className: "dsq-summary-list"
+        });
+
+        moduleSummary.questions.forEach((questionSummary) => {
+          const item = createElement("li", {
+            className: "dsq-summary-question"
+          });
+          const statusClass = questionSummary.finalCorrect
+            ? "dsq-summary-status-correct"
+            : "dsq-summary-status-incorrect";
+          const statusText = questionSummary.finalCorrect ? "Goed" : "Fout";
+          const statusEl = createElement("span", {
+            className: `dsq-summary-status ${statusClass}`,
+            text: statusText
+          });
+          const textEl = createElement("span", {
+            className: "dsq-summary-question-text",
+            text: questionSummary.questionText
+          });
+          const answerLabels = questionSummary.finalAnswerLabels.length
+            ? questionSummary.finalAnswerLabels.join(", ")
+            : "-";
+          const answerEl = createElement("span", {
+            className: "dsq-summary-answer",
+            text: `Jouw antwoord: ${answerLabels}`
+          });
+
+          item.append(statusEl, textEl, answerEl);
+          list.append(item);
+        });
+
+        moduleEl.append(list);
+        summaryCard.append(moduleEl);
+      });
+
+      return summaryCard;
     }
 
     downloadCertificate(previewEl) {
@@ -544,6 +1194,12 @@
       `;
     }
   }
+
+  global.DSQDashboard = {
+    ...(global.DSQDashboard || {}),
+    DailySessionStore,
+    DashboardView
+  };
 
   global.DigitalSafetyQuiz = DigitalSafetyQuiz;
 })(typeof window !== "undefined" ? window : this);

--- a/src/quizDashboard.js
+++ b/src/quizDashboard.js
@@ -1,0 +1,50 @@
+(function (global) {
+  "use strict";
+
+  function resolveContainer(container) {
+    if (typeof container === "string") {
+      return document.querySelector(container);
+    }
+    return container || null;
+  }
+
+  function createStore(providedStore) {
+    if (providedStore) {
+      return providedStore;
+    }
+
+    const dashboardAPI = global.DSQDashboard || {};
+    if (dashboardAPI.DailySessionStore) {
+      return new dashboardAPI.DailySessionStore();
+    }
+
+    throw new Error(
+      "DigitalSafetyDashboard: DailySessionStore is niet beschikbaar. Zorg dat digitalSafetyQuiz.js geladen is."
+    );
+  }
+
+  function createView(container, store) {
+    const dashboardAPI = global.DSQDashboard || {};
+    if (!dashboardAPI.DashboardView) {
+      throw new Error(
+        "DigitalSafetyDashboard: DashboardView is niet beschikbaar. Zorg dat digitalSafetyQuiz.js geladen is."
+      );
+    }
+
+    return new dashboardAPI.DashboardView(container, store);
+  }
+
+  function createDigitalSafetyDashboard(options = {}) {
+    const container = resolveContainer(options.container);
+    if (!container) {
+      throw new Error(
+        "DigitalSafetyDashboard: kon de container niet vinden. Geef een element of CSS-selector door."
+      );
+    }
+
+    const store = createStore(options.store);
+    return createView(container, store);
+  }
+
+  global.createDigitalSafetyDashboard = createDigitalSafetyDashboard;
+})(typeof window !== "undefined" ? window : this);

--- a/styles/digitalSafetyQuiz.css
+++ b/styles/digitalSafetyQuiz.css
@@ -195,7 +195,8 @@
   box-shadow: 0 12px 24px rgba(59, 130, 246, 0.3);
 }
 
-.dsq-button:disabled {
+.dsq-button:disabled,
+.dsq-button[disabled] {
   opacity: 0.6;
   cursor: not-allowed;
   box-shadow: none;

--- a/styles/digitalSafetyQuiz.css
+++ b/styles/digitalSafetyQuiz.css
@@ -195,6 +195,13 @@
   box-shadow: 0 12px 24px rgba(59, 130, 246, 0.3);
 }
 
+.dsq-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
 .dsq-button:focus {
   outline: 3px solid rgba(99, 102, 241, 0.4);
   outline-offset: 2px;
@@ -237,6 +244,18 @@
   outline: none;
 }
 
+.dsq-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1.25rem;
+}
+
+.dsq-label {
+  font-weight: 700;
+  color: #0f172a;
+}
+
 .dsq-certificate-preview {
   margin-top: 1.5rem;
   background: #fef9c3;
@@ -261,6 +280,180 @@
 .dsq-certificate-score {
   font-size: 1rem;
   color: #7c2d12;
+}
+
+.dsq-dashboard-page {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: linear-gradient(160deg, #0f172a, #1e3a8a 45%, #3b82f6 100%);
+  font-family: "Nunito", "Segoe UI", sans-serif;
+  padding: 2rem 1.5rem;
+  box-sizing: border-box;
+}
+
+.dsq-dashboard-wrapper {
+  width: min(960px, 100%);
+}
+
+.dsq-dashboard-page .dsq-card {
+  width: 100%;
+  margin: 0 auto;
+}
+
+.dsq-dashboard {
+  margin-bottom: 1.5rem;
+}
+
+.dsq-dashboard-title {
+  font-size: 1.25rem;
+  margin-bottom: 0.25rem;
+  color: #0f172a;
+}
+
+.dsq-dashboard-date {
+  color: #475569;
+  margin-bottom: 1rem;
+}
+
+.dsq-dashboard-metrics {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin-bottom: 1.25rem;
+}
+
+.dsq-dashboard-metric {
+  background: #f1f5f9;
+  border-radius: 16px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+}
+
+.dsq-dashboard-metric-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1d4ed8;
+}
+
+.dsq-dashboard-metric-label {
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.dsq-dashboard-subtitle {
+  font-size: 1.1rem;
+  margin: 1rem 0 0.5rem;
+  color: #0f172a;
+}
+
+.dsq-dashboard-session-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dsq-dashboard-session-item {
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: #f8fafc;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.dsq-dashboard-session-name {
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.dsq-dashboard-session-stats {
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.dsq-dashboard-session-time {
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.dsq-dashboard-session-empty {
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: #f8fafc;
+  color: #64748b;
+  font-style: italic;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+}
+
+.dsq-summary-card {
+  margin-bottom: 1.5rem;
+}
+
+.dsq-summary-intro {
+  color: #475569;
+  margin-bottom: 0.5rem;
+}
+
+.dsq-summary-score {
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 1rem;
+}
+
+.dsq-summary-module {
+  margin-top: 1rem;
+}
+
+.dsq-summary-list {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dsq-summary-question {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: #f8fafc;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+}
+
+.dsq-summary-status {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.dsq-summary-status-correct {
+  color: #15803d;
+}
+
+.dsq-summary-status-incorrect {
+  color: #b91c1c;
+}
+
+.dsq-summary-question-text {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.dsq-summary-answer {
+  font-size: 0.9rem;
+  color: #475569;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- remove the embedded dashboard from the quiz UI and expose the storage/dashboard classes for reuse
- add a standalone dashboard page with initialization script to mount the live view separately
- add styling to support the dedicated dashboard layout

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e0f41a5af48323a0666b8591c66bad