### PR TITLE
Fix next question navigation and dashboard loading

### DIFF
--- a/src/digitalSafetyQuiz.js
+++ b/src/digitalSafetyQuiz.js
@@ -794,16 +794,7 @@
       });
       nextQuestionButton.disabled = true;
 
-      let hasRecordedScore = false;
-
-      const nextQuestionButton = createElement("button", {
-        className: "dsq-button dsq-button-secondary",
-        text: this.config.strings.nextQuestion,
-        attrs: { type: "button" }
-      });
-      nextQuestionButton.disabled = true;
-
-      let hasRecordedScore = false;
+      let hasRecordedScore = this._getAttemptCount(module.id, question.id) > 0;
 
       form.addEventListener("submit", (event) => {
         event.preventDefault();


### PR DESCRIPTION
## Summary
- remove duplicated next question button declaration that broke script execution
- ensure score tracking reuses existing attempts when returning to a question

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f9a3a9388323a362b546d869aa4e