### PR TITLE
Add backend APIs and admin UI for question management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+data/*.db

--- a/README.md
+++ b/README.md
@@ -10,11 +10,22 @@ Deze repository bevat een kant-en-klare quizmodule die je kunt insluiten op bijv
 
 ## Lokaal testen
 
-Open `public/index.html` in je browser (bijvoorbeeld door het bestand te openen vanuit Finder/Explorer of met een lokale webserver).
+Installeer eerst de afhankelijkheden en start daarna de Node-server. De server levert de quizbestanden, API's en beheerschermen uit.
+
+```bash
+npm install
+npm start
+```
+
+Open vervolgens [http://localhost:3000/](http://localhost:3000/) in je browser om de quiz te bekijken. Het live dashboard is bereikbaar via `public/dashboard.html` en het beheer van vragen via `public/questions.html`.
+
+### Vragen beheren
+
+Ga naar [http://localhost:3000/questions.html](http://localhost:3000/questions.html) om het overzicht van vragen te zien. Vanuit dit scherm kun je bestaande vragen bewerken of nieuwe vragen toevoegen. Het formulier ondersteunt het aanpassen van antwoordopties, feedbackteksten en het type vraag (één antwoord of meerdere antwoorden).
 
 ## Insluiten op Wix
 
-1. Upload de bestanden `digitalSafetyQuiz.js` en `digitalSafetyQuiz.css` naar een publiek toegankelijke locatie (bijvoorbeeld GitHub, je eigen hosting of Wix Static Files).
+1. Upload de bestanden `digitalSafetyQuiz.js` en `digitalSafetyQuiz.css` naar een publiek toegankelijke locatie (bijvoorbeeld GitHub, je eigen hosting of Wix Static Files). Wanneer je de nieuwe back-end functionaliteit wilt gebruiken heb je daarnaast een server nodig die de API aanbiedt (zie bovenstaande stappen).
 2. Voeg op Wix een **Embed Code** (HTML iframe) element toe.
 3. Plak onderstaande HTML en pas zo nodig de paden naar de bestanden aan.
 

--- a/data/quizData.json
+++ b/data/quizData.json
@@ -1,0 +1,482 @@
+{
+  "title": "Digitaal Veiligheidsrijbewijs",
+  "description": "Doorloop de modules, beantwoord de vragen en verdien het certificaat voor digitale veiligheid!",
+  "certificateMessage": "Gefeliciteerd! Je hebt alle modules voltooid en toont dat jij veilig en slim online kunt zijn.",
+  "strings": {
+    "startButton": "Start de quiz",
+    "nextModule": "Volgende module",
+    "continue": "Ga verder",
+    "checkAnswer": "Controleer antwoord",
+    "nextQuestion": "Volgende vraag",
+    "selectOptions": "Selecteer je antwoord",
+    "selectMultiple": "Selecteer een of meer antwoorden",
+    "feedbackCorrect": "Goed gedaan!",
+    "feedbackIncorrect": "Probeer het nog eens.",
+    "moduleComplete": "Module afgerond!",
+    "certificateTitle": "Jouw digitale veiligheidsrijbewijs",
+    "enterName": "Vul je naam in voor op het certificaat",
+    "downloadButton": "Download als afbeelding",
+    "resetButton": "Opnieuw beginnen"
+  },
+  "modules": [
+    {
+      "id": "wachtwoorden",
+      "title": "Sterke wachtwoorden",
+      "intro": "Een sterk wachtwoord is lang, uniek en bevat cijfers, letters en symbolen. Gebruik geen informatie die andere mensen makkelijk kunnen raden, zoals je naam of verjaardag.",
+      "tips": [
+        "Maak wachtwoorden van minimaal 12 tekens",
+        "Gebruik een wachtwoordmanager of een wachtwoordzin",
+        "Deel je wachtwoord nooit met anderen"
+      ],
+      "questionsPerSession": 5,
+      "questionPool": [
+        {
+          "id": "pw-sterkste-wachtwoord",
+          "text": "Welk wachtwoord is het veiligst?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "123456" },
+            { "id": "b", "label": "voetbal" },
+            { "id": "c", "label": "H0nd!sPr!ngt" },
+            { "id": "d", "label": "qwerty" }
+          ],
+          "correct": ["c"],
+          "feedback": {
+            "correct": "Klopt! Dit wachtwoord is lang en gebruikt hoofdletters, cijfers en symbolen.",
+            "incorrect": "Niet helemaal. Kies een wachtwoord dat lang is en verschillende soorten tekens gebruikt."
+          }
+        },
+        {
+          "id": "pw-onthouden",
+          "text": "Wat is een goede manier om een wachtwoord te onthouden?",
+          "type": "single",
+          "options": [
+            {
+              "id": "a",
+              "label": "Schrijf het wachtwoord op een briefje en plak het op je scherm."
+            },
+            {
+              "id": "b",
+              "label": "Gebruik een grappige zin en maak daar een wachtwoord van."
+            },
+            { "id": "c", "label": "Gebruik hetzelfde wachtwoord voor alles." },
+            { "id": "d", "label": "Deel het met je beste vriend zodat je het niet vergeet." }
+          ],
+          "correct": ["b"],
+          "feedback": {
+            "correct": "Heel goed! Een wachtwoordzin is makkelijk te onthouden en moeilijk te raden.",
+            "incorrect": "Probeer een wachtwoordzin te gebruiken. Dat is veiliger dan overal hetzelfde wachtwoord."
+          }
+        },
+        {
+          "id": "pw-manager",
+          "text": "Waarom is een wachtwoordmanager handig?",
+          "type": "single",
+          "options": [
+            {
+              "id": "a",
+              "label": "Hij maakt automatisch unieke wachtwoorden voor al je accounts."
+            },
+            { "id": "b", "label": "Hij deelt je wachtwoorden met je vrienden." },
+            { "id": "c", "label": "Hij verandert je wachtwoorden elke dag zonder te vragen." },
+            { "id": "d", "label": "Hij onthoudt alleen simpele wachtwoorden." }
+          ],
+          "correct": ["a"],
+          "feedback": {
+            "correct": "Precies! Een wachtwoordmanager maakt unieke wachtwoorden en bewaart ze veilig.",
+            "incorrect": "Een wachtwoordmanager helpt je om sterke, unieke wachtwoorden te maken en te bewaren."
+          }
+        },
+        {
+          "id": "pw-elk-account",
+          "text": "Waarom moet je voor elk account een ander wachtwoord gebruiken?",
+          "type": "single",
+          "options": [
+            {
+              "id": "a",
+              "label": "Omdat het anders te veel tijd kost om in te loggen."
+            },
+            {
+              "id": "b",
+              "label": "Omdat als één wachtwoord wordt gestolen, de andere accounts dan veilig blijven."
+            },
+            { "id": "c", "label": "Omdat websites dat verplichten." },
+            { "id": "d", "label": "Omdat korte wachtwoorden niet werken." }
+          ],
+          "correct": ["b"],
+          "feedback": {
+            "correct": "Juist! Zo voorkom je dat iemand meteen overal kan inloggen.",
+            "incorrect": "Als één wachtwoord uitlekt kunnen anderen anders al je accounts gebruiken."
+          }
+        },
+        {
+          "id": "pw-symbool",
+          "text": "Welke combinatie maakt een wachtwoord extra sterk?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Alleen kleine letters" },
+            { "id": "b", "label": "Kleine letters en cijfers" },
+            { "id": "c", "label": "Hoofdletters, kleine letters, cijfers en symbolen" },
+            { "id": "d", "label": "Alleen emoji" }
+          ],
+          "correct": ["c"],
+          "feedback": {
+            "correct": "Yes! Hoe meer variatie, hoe moeilijker het is om je wachtwoord te raden.",
+            "incorrect": "Gebruik verschillende soorten tekens voor een sterk wachtwoord."
+          }
+        },
+        {
+          "id": "pw-waarschuwing",
+          "text": "Je krijgt een melding dat een wachtwoord mogelijk is gelekt. Wat doe je?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Niets, meldingen zijn nooit belangrijk." },
+            { "id": "b", "label": "Ik verander meteen het wachtwoord." },
+            { "id": "c", "label": "Ik deel de melding met vrienden." },
+            { "id": "d", "label": "Ik verwijder het account." }
+          ],
+          "correct": ["b"],
+          "feedback": {
+            "correct": "Goed gezien! Verander het wachtwoord direct om je account te beschermen.",
+            "incorrect": "Reageer op een waarschuwing door het wachtwoord snel te veranderen."
+          }
+        },
+        {
+          "id": "pw-twee-stappen",
+          "text": "Wat doet tweestapsverificatie (2FA)?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Het laat je sneller inloggen." },
+            {
+              "id": "b",
+              "label": "Het vraagt om een extra bevestiging, zoals een code op je telefoon."
+            },
+            { "id": "c", "label": "Het maakt je wachtwoord zichtbaar." },
+            { "id": "d", "label": "Het verwijdert oude wachtwoorden." }
+          ],
+          "correct": ["b"],
+          "feedback": {
+            "correct": "Klopt! Het extra slotje maakt het veel moeilijker om in te breken.",
+            "incorrect": "Tweestapsverificatie vraagt om een extra bevestiging voor extra veiligheid."
+          }
+        },
+        {
+          "id": "pw-voorbeeld",
+          "text": "Welke wachtwoordzin is het sterkst?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "ikhouvanpizza" },
+            { "id": "b", "label": "P1zzaIsLekk3r!" },
+            { "id": "c", "label": "pizzapizza" },
+            { "id": "d", "label": "12345pizza" }
+          ],
+          "correct": ["b"],
+          "feedback": {
+            "correct": "Lekker bezig! Deze zin is lang en bevat verschillende soorten tekens.",
+            "incorrect": "Kies een wachtwoordzin die lang is en cijfers en symbolen gebruikt."
+          }
+        }
+      ]
+    },
+    {
+      "id": "delen",
+      "title": "Slim delen",
+      "intro": "Op internet hoef je niet alles te delen. Denk na voordat je iets plaatst of verstuurt. Vraag jezelf af: zou ik dit ook in de klas laten zien?",
+      "tips": [
+        "Plaats geen persoonlijke gegevens zoals adressen of telefoonnummers",
+        "Vraag toestemming voordat je foto's van anderen deelt",
+        "Zet je profiel op privé wanneer mogelijk"
+      ],
+      "questionsPerSession": 5,
+      "questionPool": [
+        {
+          "id": "share-toestemming",
+          "text": "Je wilt een leuke foto van een klasgenoot delen. Wat doe je?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Ik plaats de foto meteen." },
+            { "id": "b", "label": "Ik vraag eerst of het mag." },
+            { "id": "c", "label": "Ik stuur de foto naar iedereen in mijn contacten." },
+            { "id": "d", "label": "Ik bewerk de foto zodat niemand hem herkent." }
+          ],
+          "correct": ["b"],
+          "feedback": {
+            "correct": "Super! Vraag altijd toestemming voordat je iets deelt wat niet van jou is.",
+            "incorrect": "Vraag altijd eerst toestemming voordat je een foto deelt."
+          }
+        },
+        {
+          "id": "share-privé",
+          "text": "Welke informatie kun je het beste voor jezelf houden?",
+          "type": "multiple",
+          "options": [
+            { "id": "a", "label": "Je lievelingskleur" },
+            { "id": "b", "label": "Je thuisadres" },
+            { "id": "c", "label": "Je geheime wachtwoord" },
+            { "id": "d", "label": "Je favoriete dier" }
+          ],
+          "correct": ["b", "c"],
+          "feedback": {
+            "correct": "Goed gedaan! Adressen en wachtwoorden zijn privé.",
+            "incorrect": "Denk eraan dat persoonlijke gegevens zoals adressen en wachtwoorden geheim moeten blijven."
+          }
+        },
+        {
+          "id": "share-story",
+          "text": "Wat controleer je voordat je iets in je story plaatst?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Of er persoonlijke informatie zichtbaar is." },
+            { "id": "b", "label": "Of je genoeg likes krijgt." },
+            { "id": "c", "label": "Of je vrienden er ook iets op hebben gezet." },
+            { "id": "d", "label": "Of het filter grappig genoeg is." }
+          ],
+          "correct": ["a"],
+          "feedback": {
+            "correct": "Top! Controleer altijd wat je laat zien voordat je iets deelt.",
+            "incorrect": "Kijk of er persoonlijke informatie te zien is voordat je post."
+          }
+        },
+        {
+          "id": "share-prive-stand",
+          "text": "Waarom is het slim om je account op privé te zetten?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Dan kunnen alleen mensen die jij kiest je volgen." },
+            { "id": "b", "label": "Dan krijg je automatisch meer likes." },
+            { "id": "c", "label": "Dan hoef je nooit meer een wachtwoord te gebruiken." },
+            { "id": "d", "label": "Dan verdwijnen oude berichten." }
+          ],
+          "correct": ["a"],
+          "feedback": {
+            "correct": "Juist! Zo bepaal jij wie je berichten kan zien.",
+            "incorrect": "Op privé bepalen alleen jouw volgers wat je deelt."
+          }
+        },
+        {
+          "id": "share-opinie",
+          "text": "Je leest een spannend bericht en wilt het delen. Wat is verstandig?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Eerst controleren of het nieuws echt klopt." },
+            { "id": "b", "label": "Het meteen delen zodat iedereen het ziet." },
+            { "id": "c", "label": "Alleen de titel lezen en delen." },
+            { "id": "d", "label": "Een eigen verhaal erbij verzinnen." }
+          ],
+          "correct": ["a"],
+          "feedback": {
+            "correct": "Goed! Controleer bronnen voordat je iets verder verspreidt.",
+            "incorrect": "Controleer eerst of het bericht betrouwbaar is voordat je het deelt."
+          }
+        },
+        {
+          "id": "share-locatie",
+          "text": "Wanneer deel je het beste je locatie op sociale media?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Nooit, want locatie is altijd geheim." },
+            {
+              "id": "b",
+              "label": "Alleen als je zeker weet dat het veilig is en je ouders het goed vinden."
+            },
+            { "id": "c", "label": "Altijd, zodat iedereen weet waar je bent." },
+            { "id": "d", "label": "Alleen 's nachts." }
+          ],
+          "correct": ["b"],
+          "feedback": {
+            "correct": "Precies! Wees voorzichtig met het delen van je locatie.",
+            "incorrect": "Deel je locatie alleen als je zeker weet dat het veilig is."
+          }
+        },
+        {
+          "id": "share-bericht",
+          "text": "Iemand vraagt je in een chat om een gênante foto van jezelf. Wat doe je?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Ik stuur de foto om aardig te zijn." },
+            { "id": "b", "label": "Ik maak een grap en stuur toch iets." },
+            {
+              "id": "c",
+              "label": "Ik stuur niets en vertel het aan een volwassene die ik vertrouw."
+            },
+            { "id": "d", "label": "Ik vraag andere vrienden wat zij zouden doen en stuur het dan." }
+          ],
+          "correct": ["c"],
+          "feedback": {
+            "correct": "Heel goed! Deel nooit iets waar je je niet prettig bij voelt en vertel het aan een volwassene.",
+            "incorrect": "Deel geen gênante foto's en praat met iemand die je vertrouwt."
+          }
+        },
+        {
+          "id": "share-reageren",
+          "text": "Je ziet een gemene reactie onder een foto van een klasgenoot. Wat kun je doen?",
+          "type": "multiple",
+          "options": [
+            { "id": "a", "label": "De reactie melden bij het platform." },
+            { "id": "b", "label": "Een aardige reactie plaatsen ter ondersteuning." },
+            { "id": "c", "label": "Zelf ook een gemene reactie plaatsen." },
+            { "id": "d", "label": "Er met een volwassene over praten." }
+          ],
+          "correct": ["a", "b", "d"],
+          "feedback": {
+            "correct": "Goed dat je het probleem aanpakt en steun geeft!",
+            "incorrect": "Meld nare reacties, bied steun en bespreek het met een volwassene."
+          }
+        }
+      ]
+    },
+    {
+      "id": "online-vrienden",
+      "title": "Online vrienden",
+      "intro": "Niet iedereen online is wie hij zegt dat hij is. Wees voorzichtig met nieuwe online vrienden en bespreek vreemde situaties met een volwassene die je vertrouwt.",
+      "tips": [
+        "Accepteer geen vriendschapsverzoeken van onbekenden",
+        "Praat met je ouders of leerkracht als iemand je ongemakkelijk laat voelen",
+        "Spreek niet af met iemand die je alleen via internet kent"
+      ],
+      "questionsPerSession": 5,
+      "questionPool": [
+        {
+          "id": "friends-bericht",
+          "text": "Wat doe je als iemand die je niet kent je een bericht stuurt?",
+          "type": "single",
+          "options": [
+            {
+              "id": "a",
+              "label": "Ik reageer meteen en vertel veel over mezelf."
+            },
+            {
+              "id": "b",
+              "label": "Ik vertel het aan een volwassene die ik vertrouw."
+            },
+            { "id": "c", "label": "Ik ga met die persoon afspreken." },
+            { "id": "d", "label": "Ik stuur mijn telefoonnummer." }
+          ],
+          "correct": ["b"],
+          "feedback": {
+            "correct": "Heel goed! Praat altijd met een volwassene als iemand je iets vreemd vraagt.",
+            "incorrect": "Vertel het aan een volwassene die je vertrouwt en reageer niet zomaar."
+          }
+        },
+        {
+          "id": "friends-afspraak",
+          "text": "Iemand die je online kent vraagt om af te spreken. Wat is verstandig?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Ik ga erheen en vertel het niemand." },
+            {
+              "id": "b",
+              "label": "Ik vertel mijn ouders of leerkracht en ga niet zonder hun toestemming."
+            },
+            { "id": "c", "label": "Ik neem al mijn vrienden mee." },
+            { "id": "d", "label": "Ik vraag om een cadeau in ruil voor een ontmoeting." }
+          ],
+          "correct": ["b"],
+          "feedback": {
+            "correct": "Juist! Spreek nooit af zonder toestemming van een volwassene.",
+            "incorrect": "Vertel het altijd aan een volwassene en ga niet zomaar naar een afspraak."
+          }
+        },
+        {
+          "id": "friends-profiel",
+          "text": "Hoe herken je een nepaccount?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Er staan weinig foto's of rare berichten op." },
+            { "id": "b", "label": "Ze hebben altijd heel veel volgers." },
+            { "id": "c", "label": "Het account is ouder dan een jaar." },
+            { "id": "d", "label": "Ze gebruiken emoji in hun naam." }
+          ],
+          "correct": ["a"],
+          "feedback": {
+            "correct": "Goed gezien! Nepaccounts hebben vaak weinig echte informatie.",
+            "incorrect": "Let op accounts met weinig informatie of vreemde berichten."
+          }
+        },
+        {
+          "id": "friends-geheim",
+          "text": "Een online vriend vraagt je om jullie gesprekken geheim te houden. Wat doe je?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Ik doe wat hij vraagt, want geheimen zijn spannend." },
+            { "id": "b", "label": "Ik vertel het aan een volwassene die ik vertrouw." },
+            { "id": "c", "label": "Ik vertel het aan mijn vrienden maar niet aan volwassenen." },
+            { "id": "d", "label": "Ik antwoord niet en verwijder het gesprek." }
+          ],
+          "correct": ["b"],
+          "feedback": {
+            "correct": "Heel goed! Vertel een volwassene als iemand om geheimhouding vraagt.",
+            "incorrect": "Geheimen die je onzeker maken deel je altijd met een volwassene."
+          }
+        },
+        {
+          "id": "friends-spel",
+          "text": "Je speelt een online spel en iemand vraagt om via een andere app te chatten. Wat is verstandig?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Ik ga meteen over naar de andere app." },
+            {
+              "id": "b",
+              "label": "Alleen met mensen die ik in het echt ken of die door een volwassene zijn goedgekeurd."
+            },
+            { "id": "c", "label": "Met mensen die veel prijzen hebben gewonnen." },
+            { "id": "d", "label": "Met degene die het hardst schreeuwt." }
+          ],
+          "correct": ["b"],
+          "feedback": {
+            "correct": "Goed! Chat alleen met mensen die je vertrouwt of die zijn goedgekeurd.",
+            "incorrect": "Blijf bij mensen die je kent of die door een volwassene zijn goedgekeurd."
+          }
+        },
+        {
+          "id": "friends-prijs",
+          "text": "Je wint zogenaamd een prijs via een chatbericht en moet je gegevens invullen. Wat doe je?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Ik geef al mijn gegevens door zodat ik de prijs krijg." },
+            { "id": "b", "label": "Ik klik op de link en kijk wel wat er gebeurt." },
+            { "id": "c", "label": "Ik verwijder het bericht en meld het aan een volwassene." },
+            { "id": "d", "label": "Ik vraag om een grotere prijs." }
+          ],
+          "correct": ["c"],
+          "feedback": {
+            "correct": "Heel goed! Dit kan phishing zijn, dus verwijder het bericht en waarschuw iemand.",
+            "incorrect": "Geef geen gegevens door bij verdachte berichten en vertel het aan een volwassene."
+          }
+        },
+        {
+          "id": "friends-wachtwoord",
+          "text": "Een online vriend vraagt om je wachtwoord zodat hij kan helpen. Wat doe je?",
+          "type": "single",
+          "options": [
+            { "id": "a", "label": "Ik geef mijn wachtwoord, want hij lijkt aardig." },
+            { "id": "b", "label": "Ik bedank hem maar deel mijn wachtwoord niet." },
+            { "id": "c", "label": "Ik stuur het wachtwoord via een geheime code." },
+            { "id": "d", "label": "Ik verander mijn wachtwoord en stuur het daarna." }
+          ],
+          "correct": ["b"],
+          "feedback": {
+            "correct": "Precies! Deel je wachtwoord nooit, ook niet met vrienden.",
+            "incorrect": "Wachtwoorden zijn altijd privé, deel ze met niemand."
+          }
+        },
+        {
+          "id": "friends-gevoel",
+          "text": "Iemand online maakt je onzeker of bang. Wat kun je doen?",
+          "type": "multiple",
+          "options": [
+            { "id": "a", "label": "Het gesprek stoppen en de persoon blokkeren." },
+            { "id": "b", "label": "Een volwassene die je vertrouwt om hulp vragen." },
+            { "id": "c", "label": "Doorgaan met chatten zodat het misschien stopt." },
+            { "id": "d", "label": "Bewijs bewaren door een screenshot te maken." }
+          ],
+          "correct": ["a", "b", "d"],
+          "feedback": {
+            "correct": "Goed gedaan! Stop het gesprek, bewaar bewijs en zoek hulp.",
+            "incorrect": "Stop de chat, blokkeer de persoon, maak een screenshot en vertel het aan een volwassene."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2651 @@
+{
+  "name": "chatspel",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "chatspel",
+      "version": "1.0.0",
+      "dependencies": {
+        "cors": "^2.8.5",
+        "express": "^4.19.2",
+        "sqlite3": "^5.1.6"
+      },
+      "devDependencies": {
+        "nodemon": "^3.0.2"
+      }
+    },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@npmcli/fs": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.2.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.0.0",
+        "ssri": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.12"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^9.1.0",
+        "nopt": "^5.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
+      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nodemon/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/sqlite3": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
+      "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1",
+        "tar": "^6.1.11"
+      },
+      "optionalDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependenciesMeta": {
+        "node-gyp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "chatspel",
+  "version": "1.0.0",
+  "description": "Digitale veiligheidsquiz met backend",
+  "main": "server/index.js",
+  "scripts": {
+    "start": "node server/index.js",
+    "dev": "nodemon server/index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "sqlite3": "^5.1.6"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.2"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -15,10 +15,29 @@
     ></script>
     <script src="../src/digitalSafetyQuiz.js"></script>
     <script>
-      document.addEventListener("DOMContentLoaded", function () {
-        new DigitalSafetyQuiz({
-          container: "#quiz"
-        });
+      document.addEventListener("DOMContentLoaded", async function () {
+        const container = document.querySelector("#quiz");
+        if (container) {
+          container.textContent = "Quiz wordt geladen...";
+        }
+
+        try {
+          const response = await fetch("/api/quiz-config");
+          if (!response.ok) {
+            throw new Error("Kon configuratie niet laden");
+          }
+          const config = await response.json();
+          new DigitalSafetyQuiz({
+            container: "#quiz",
+            config,
+            apiBaseUrl: ""
+          });
+        } catch (error) {
+          if (container) {
+            container.textContent =
+              "De quiz kon niet worden geladen. Probeer het later opnieuw.";
+          }
+        }
       });
     </script>
   </body>

--- a/public/question-editor.html
+++ b/public/question-editor.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vraag bewerken</title>
+    <link rel="stylesheet" href="../styles/admin.css" />
+  </head>
+  <body>
+    <main class="admin-container">
+      <header class="admin-header">
+        <h1 id="editor-title">Nieuwe vraag</h1>
+        <a class="admin-button admin-secondary" href="questions.html">Terug naar overzicht</a>
+      </header>
+      <section class="admin-card">
+        <div id="editor-feedback"></div>
+        <form class="admin-form" id="question-form">
+          <div class="admin-field">
+            <label for="question-module">Categorie</label>
+            <select id="question-module" required></select>
+          </div>
+          <div class="admin-field">
+            <label for="question-text">Vraag</label>
+            <textarea id="question-text" rows="3" required></textarea>
+          </div>
+          <div class="admin-field">
+            <label for="question-type">Type vraag</label>
+            <select id="question-type">
+              <option value="single">Meerkeuze (1 antwoord)</option>
+              <option value="multiple">Meerkeuze (meerdere antwoorden)</option>
+            </select>
+          </div>
+          <div class="admin-field">
+            <label>Antwoorden</label>
+            <div class="admin-options" id="options-list"></div>
+            <button type="button" class="admin-button admin-secondary" id="add-option">
+              Optie toevoegen
+            </button>
+          </div>
+          <div class="admin-field">
+            <label for="feedback-correct">Feedback bij goed antwoord</label>
+            <textarea id="feedback-correct" rows="2"></textarea>
+          </div>
+          <div class="admin-field">
+            <label for="feedback-incorrect">Feedback bij fout antwoord</label>
+            <textarea id="feedback-incorrect" rows="2"></textarea>
+          </div>
+          <div class="admin-actions">
+            <button type="submit" class="admin-button">Opslaan</button>
+            <button type="button" class="admin-button admin-secondary" id="cancel-button">
+              Annuleren
+            </button>
+          </div>
+        </form>
+      </section>
+    </main>
+    <script src="../src/questionEditor.js" defer></script>
+  </body>
+</html>

--- a/public/questions.html
+++ b/public/questions.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vragenbeheer</title>
+    <link rel="stylesheet" href="../styles/admin.css" />
+  </head>
+  <body>
+    <main class="admin-container">
+      <header class="admin-header">
+        <h1>Vragenbeheer</h1>
+        <a class="admin-button" href="question-editor.html">Nieuwe vraag</a>
+      </header>
+      <section class="admin-card" id="questions-card">
+        <div id="questions-feedback"></div>
+        <table class="admin-table" id="questions-table" hidden>
+          <thead>
+            <tr>
+              <th>Vraag</th>
+              <th>Categorie</th>
+              <th>Type</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <div class="admin-empty" id="questions-empty" hidden>
+          Geen vragen gevonden.
+        </div>
+      </section>
+    </main>
+    <script src="../src/adminQuestions.js" defer></script>
+  </body>
+</html>

--- a/server/database.js
+++ b/server/database.js
@@ -1,0 +1,11 @@
+const path = require("path");
+const sqlite3 = require("sqlite3").verbose();
+
+const dbPath = path.join(__dirname, "..", "data", "quiz.db");
+const db = new sqlite3.Database(dbPath);
+
+db.serialize(() => {
+  db.run("PRAGMA foreign_keys = ON");
+});
+
+module.exports = db;

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,460 @@
+const express = require("express");
+const path = require("path");
+const cors = require("cors");
+const { randomUUID } = require("crypto");
+
+const {
+  initializeDatabase,
+  getQuizConfig,
+  runQuery,
+  allQuery,
+  getQuery
+} = require("./initializeDatabase");
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const SESSION_TIMEOUT_MS = parseInt(process.env.SESSION_TIMEOUT_MS || "60000", 10);
+
+app.use(cors());
+app.use(express.json());
+
+app.use(express.static(path.join(__dirname, "..", "public")));
+app.use("/styles", express.static(path.join(__dirname, "..", "styles")));
+app.use("/src", express.static(path.join(__dirname, "..", "src")));
+
+function asyncHandler(fn) {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
+
+function sanitizeOptions(options = []) {
+  if (!Array.isArray(options)) {
+    return [];
+  }
+  return options
+    .map((option) => ({
+      id: option.id || randomUUID(),
+      label: option.label || "",
+      isCorrect: Boolean(option.isCorrect || option.is_correct)
+    }))
+    .filter((option) => option.label.trim().length > 0);
+}
+
+async function getModuleById(moduleId) {
+  return getQuery("SELECT * FROM modules WHERE id = ?", [moduleId]);
+}
+
+async function getQuestionWithOptions(questionId) {
+  const question = await getQuery(
+    "SELECT * FROM questions WHERE id = ?",
+    [questionId]
+  );
+  if (!question) {
+    return null;
+  }
+
+  const options = await allQuery(
+    "SELECT * FROM options WHERE question_id = ? ORDER BY position ASC",
+    [questionId]
+  );
+
+  return {
+    ...question,
+    options: options.map((option) => ({
+      id: option.id,
+      label: option.label,
+      isCorrect: Boolean(option.is_correct)
+    }))
+  };
+}
+
+async function saveQuestionOptions(questionId, options) {
+  await runQuery("DELETE FROM options WHERE question_id = ?", [questionId]);
+
+  for (let index = 0; index < options.length; index += 1) {
+    const option = options[index];
+    await runQuery(
+      `INSERT INTO options (id, question_id, label, is_correct, position)
+       VALUES (?, ?, ?, ?, ?)`,
+      [
+        option.id || randomUUID(),
+        questionId,
+        option.label || "",
+        option.isCorrect ? 1 : 0,
+        index
+      ]
+    );
+  }
+}
+
+app.get(
+  "/api/quiz-config",
+  asyncHandler(async (req, res) => {
+    const config = await getQuizConfig();
+    res.json(config);
+  })
+);
+
+app.get(
+  "/api/modules",
+  asyncHandler(async (req, res) => {
+    const modules = await allQuery(
+      "SELECT id, title, questions_per_session AS questionsPerSession FROM modules ORDER BY position ASC"
+    );
+    res.json(modules);
+  })
+);
+
+app.get(
+  "/api/questions",
+  asyncHandler(async (req, res) => {
+    const rows = await allQuery(
+      `SELECT q.id, q.text, q.type, q.module_id AS moduleId, q.position,
+              m.title AS moduleTitle
+       FROM questions q
+       INNER JOIN modules m ON q.module_id = m.id
+       ORDER BY m.position ASC, q.position ASC`
+    );
+    res.json(rows);
+  })
+);
+
+app.get(
+  "/api/questions/:id",
+  asyncHandler(async (req, res) => {
+    const question = await getQuestionWithOptions(req.params.id);
+    if (!question) {
+      res.status(404).json({ message: "Vraag niet gevonden" });
+      return;
+    }
+    res.json({
+      id: question.id,
+      moduleId: question.module_id,
+      text: question.text,
+      type: question.type,
+      feedback: {
+        correct: question.feedback_correct || "",
+        incorrect: question.feedback_incorrect || ""
+      },
+      options: question.options
+    });
+  })
+);
+
+app.post(
+  "/api/questions",
+  asyncHandler(async (req, res) => {
+    const { moduleId, text, type = "single", feedback = {}, options = [] } =
+      req.body || {};
+
+    if (!moduleId || !text) {
+      res.status(400).json({ message: "moduleId en text zijn verplicht" });
+      return;
+    }
+
+    const module = await getModuleById(moduleId);
+    if (!module) {
+      res.status(404).json({ message: "Module niet gevonden" });
+      return;
+    }
+
+    const sanitizedOptions = sanitizeOptions(options);
+    if (!sanitizedOptions.length) {
+      res.status(400).json({ message: "Voeg minimaal één antwoordoptie toe" });
+      return;
+    }
+
+    const hasCorrect = sanitizedOptions.some((option) => option.isCorrect);
+    if (!hasCorrect) {
+      res.status(400).json({ message: "Markeer minimaal één juist antwoord" });
+      return;
+    }
+
+    const now = Date.now();
+    const positionRow = await getQuery(
+      "SELECT COALESCE(MAX(position), -1) AS maxPosition FROM questions WHERE module_id = ?",
+      [moduleId]
+    );
+    const nextPosition = (positionRow?.maxPosition || -1) + 1;
+
+    const questionId = randomUUID();
+    await runQuery(
+      `INSERT INTO questions (id, module_id, text, type, feedback_correct, feedback_incorrect, position)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        questionId,
+        moduleId,
+        text,
+        type,
+        feedback.correct || "",
+        feedback.incorrect || "",
+        nextPosition
+      ]
+    );
+
+    await saveQuestionOptions(questionId, sanitizedOptions);
+
+    res.status(201).json({ id: questionId });
+  })
+);
+
+app.put(
+  "/api/questions/:id",
+  asyncHandler(async (req, res) => {
+    const { moduleId, text, type = "single", feedback = {}, options = [] } =
+      req.body || {};
+
+    if (!moduleId || !text) {
+      res.status(400).json({ message: "moduleId en text zijn verplicht" });
+      return;
+    }
+
+    const existing = await getQuestionWithOptions(req.params.id);
+    if (!existing) {
+      res.status(404).json({ message: "Vraag niet gevonden" });
+      return;
+    }
+
+    const module = await getModuleById(moduleId);
+    if (!module) {
+      res.status(404).json({ message: "Module niet gevonden" });
+      return;
+    }
+
+    const sanitizedOptions = sanitizeOptions(options);
+    if (!sanitizedOptions.length) {
+      res.status(400).json({ message: "Voeg minimaal één antwoordoptie toe" });
+      return;
+    }
+
+    const hasCorrect = sanitizedOptions.some((option) => option.isCorrect);
+    if (!hasCorrect) {
+      res.status(400).json({ message: "Markeer minimaal één juist antwoord" });
+      return;
+    }
+
+    await runQuery(
+      `UPDATE questions
+       SET module_id = ?, text = ?, type = ?, feedback_correct = ?, feedback_incorrect = ?
+       WHERE id = ?`,
+      [
+        moduleId,
+        text,
+        type,
+        feedback.correct || "",
+        feedback.incorrect || "",
+        req.params.id
+      ]
+    );
+
+    await saveQuestionOptions(req.params.id, sanitizedOptions);
+
+    res.json({ id: req.params.id });
+  })
+);
+
+app.post(
+  "/api/sessions",
+  asyncHandler(async (req, res) => {
+    const name = req.body?.name || null;
+    const requestedId = req.body?.id;
+    const now = new Date();
+    const id = requestedId || randomUUID();
+    const iso = now.toISOString();
+
+    await runQuery(
+      `INSERT INTO sessions (id, name, status, start_time, last_seen)
+       VALUES (?, ?, 'active', ?, ?)`,
+      [id, name, iso, iso]
+    );
+
+    res.status(201).json({
+      id,
+      name,
+      status: "active",
+      startTime: iso,
+      lastSeen: iso
+    });
+  })
+);
+
+app.post(
+  "/api/sessions/:id/heartbeat",
+  asyncHandler(async (req, res) => {
+    const id = req.params.id;
+    const now = new Date().toISOString();
+    await runQuery(
+      `UPDATE sessions
+       SET last_seen = ?, status = CASE WHEN status = 'completed' THEN status ELSE 'active' END
+       WHERE id = ?`,
+      [now, id]
+    );
+    res.json({ lastSeen: now });
+  })
+);
+
+app.post(
+  "/api/sessions/:id/attempt",
+  asyncHandler(async (req, res) => {
+    const id = req.params.id;
+    const { moduleId, questionId, selectedOptionIds = [], isCorrect = false } =
+      req.body || {};
+
+    const now = new Date().toISOString();
+    await runQuery(
+      `INSERT INTO session_attempts (session_id, module_id, question_id, selected_options, is_correct, answered_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        moduleId || null,
+        questionId || null,
+        JSON.stringify(selectedOptionIds || []),
+        isCorrect ? 1 : 0,
+        now
+      ]
+    );
+
+    await runQuery(
+      `UPDATE sessions
+       SET last_seen = ?, status = CASE WHEN status = 'completed' THEN status ELSE 'active' END
+       WHERE id = ?`,
+      [now, id]
+    );
+
+    res.status(201).json({});
+  })
+);
+
+app.post(
+  "/api/sessions/:id/complete",
+  asyncHandler(async (req, res) => {
+    const id = req.params.id;
+    const summary = req.body?.summary || null;
+    const now = new Date().toISOString();
+
+    await runQuery(
+      `UPDATE sessions
+       SET status = 'completed', summary = ?, end_time = ?, last_seen = ?
+       WHERE id = ?`,
+      [summary ? JSON.stringify(summary) : null, now, now, id]
+    );
+
+    res.json({ endTime: now });
+  })
+);
+
+app.post(
+  "/api/sessions/:id/leave",
+  asyncHandler(async (req, res) => {
+    const id = req.params.id;
+    const now = new Date().toISOString();
+    await runQuery(
+      `UPDATE sessions
+       SET status = CASE WHEN status = 'completed' THEN status ELSE 'inactive' END,
+           end_time = COALESCE(end_time, ?),
+           last_seen = ?
+       WHERE id = ?`,
+      [now, now, id]
+    );
+    res.json({});
+  })
+);
+
+app.get(
+  "/api/dashboard",
+  asyncHandler(async (req, res) => {
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+    const startIso = startOfDay.toISOString();
+
+    const sessions = await allQuery(
+      `SELECT * FROM sessions WHERE start_time >= ? ORDER BY start_time DESC`,
+      [startIso]
+    );
+
+    if (!sessions.length) {
+      res.json({
+        totalSessions: 0,
+        totalCorrect: 0,
+        totalIncorrect: 0,
+        activeParticipants: 0,
+        activeSessions: []
+      });
+      return;
+    }
+
+    const sessionIds = sessions.map((session) => session.id);
+    const attemptRows = await allQuery(
+      `SELECT session_id AS sessionId,
+              SUM(CASE WHEN is_correct = 1 THEN 1 ELSE 0 END) AS correct,
+              SUM(CASE WHEN is_correct = 0 THEN 1 ELSE 0 END) AS incorrect
+       FROM session_attempts
+       WHERE session_id IN (${sessionIds.map(() => "?").join(",")})
+       GROUP BY session_id`,
+      sessionIds
+    );
+
+    const attemptsMap = attemptRows.reduce((acc, row) => {
+      acc[row.sessionId] = {
+        correct: row.correct || 0,
+        incorrect: row.incorrect || 0
+      };
+      return acc;
+    }, {});
+
+    const cutoff = new Date(Date.now() - SESSION_TIMEOUT_MS).toISOString();
+
+    let totalCorrect = 0;
+    let totalIncorrect = 0;
+    const activeSessions = [];
+
+    sessions.forEach((session) => {
+      const stats = attemptsMap[session.id] || { correct: 0, incorrect: 0 };
+      totalCorrect += stats.correct;
+      totalIncorrect += stats.incorrect;
+
+      if (
+        session.status === "active" &&
+        session.last_seen &&
+        session.last_seen >= cutoff
+      ) {
+        activeSessions.push({
+          id: session.id,
+          name: session.name,
+          correct: stats.correct,
+          incorrect: stats.incorrect,
+          startTime: session.start_time,
+          lastSeen: session.last_seen
+        });
+      }
+    });
+
+    res.json({
+      totalSessions: sessions.length,
+      totalCorrect,
+      totalIncorrect,
+      activeParticipants: activeSessions.length,
+      activeSessions
+    });
+  })
+);
+
+app.use((err, req, res, next) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  res.status(500).json({ message: "Er is iets misgegaan" });
+});
+
+initializeDatabase()
+  .then(() => {
+    app.listen(PORT, () => {
+      // eslint-disable-next-line no-console
+      console.log(`Server gestart op poort ${PORT}`);
+    });
+  })
+  .catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error("Database-initialisatie mislukt", error);
+    process.exit(1);
+  });

--- a/server/initializeDatabase.js
+++ b/server/initializeDatabase.js
@@ -1,0 +1,300 @@
+const fs = require("fs");
+const path = require("path");
+const { randomUUID } = require("crypto");
+const db = require("./database");
+
+function runQuery(query, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(query, params, function (err) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(this);
+      }
+    });
+  });
+}
+
+function getQuery(query, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(query, params, (err, row) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(row);
+      }
+    });
+  });
+}
+
+function allQuery(query, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(query, params, (err, rows) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(rows);
+      }
+    });
+  });
+}
+
+async function createSchema() {
+  await runQuery(`
+    CREATE TABLE IF NOT EXISTS quiz_settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `);
+
+  await runQuery(`
+    CREATE TABLE IF NOT EXISTS modules (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      intro TEXT,
+      tips TEXT,
+      questions_per_session INTEGER NOT NULL DEFAULT 0,
+      position INTEGER NOT NULL DEFAULT 0
+    )
+  `);
+
+  await runQuery(`
+    CREATE TABLE IF NOT EXISTS questions (
+      id TEXT PRIMARY KEY,
+      module_id TEXT NOT NULL,
+      text TEXT NOT NULL,
+      type TEXT NOT NULL,
+      feedback_correct TEXT,
+      feedback_incorrect TEXT,
+      position INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (module_id) REFERENCES modules(id) ON DELETE CASCADE
+    )
+  `);
+
+  await runQuery(`
+    CREATE TABLE IF NOT EXISTS options (
+      id TEXT PRIMARY KEY,
+      question_id TEXT NOT NULL,
+      label TEXT NOT NULL,
+      is_correct INTEGER NOT NULL DEFAULT 0,
+      position INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (question_id) REFERENCES questions(id) ON DELETE CASCADE
+    )
+  `);
+
+  await runQuery(`
+    CREATE TABLE IF NOT EXISTS sessions (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      status TEXT NOT NULL DEFAULT 'active',
+      start_time TEXT NOT NULL,
+      end_time TEXT,
+      last_seen TEXT NOT NULL,
+      summary TEXT
+    )
+  `);
+
+  await runQuery(`
+    CREATE TABLE IF NOT EXISTS session_attempts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      module_id TEXT,
+      question_id TEXT,
+      selected_options TEXT,
+      is_correct INTEGER NOT NULL DEFAULT 0,
+      answered_at TEXT NOT NULL,
+      FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE,
+      FOREIGN KEY (question_id) REFERENCES questions(id) ON DELETE SET NULL
+    )
+  `);
+}
+
+async function seedFromFile() {
+  const row = await getQuery("SELECT COUNT(*) AS count FROM modules");
+  if (row && row.count > 0) {
+    return;
+  }
+
+  const dataPath = path.join(__dirname, "..", "data", "quizData.json");
+  const raw = fs.readFileSync(dataPath, "utf8");
+  const parsed = JSON.parse(raw);
+
+  const { modules = [], strings = {}, title, description, certificateMessage } = parsed;
+
+  await runQuery("DELETE FROM quiz_settings");
+
+  const settingsEntries = [
+    ["title", title || ""],
+    ["description", description || ""],
+    ["certificateMessage", certificateMessage || ""],
+    ["strings", JSON.stringify(strings || {})]
+  ];
+
+  for (const [key, value] of settingsEntries) {
+    await runQuery("INSERT INTO quiz_settings (key, value) VALUES (?, ?)", [
+      key,
+      value
+    ]);
+  }
+
+  for (let moduleIndex = 0; moduleIndex < modules.length; moduleIndex += 1) {
+    const module = modules[moduleIndex];
+    const moduleId = module.id || randomUUID();
+
+    await runQuery(
+      `INSERT INTO modules (id, title, intro, tips, questions_per_session, position)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        moduleId,
+        module.title || "", 
+        module.intro || "",
+        JSON.stringify(module.tips || []),
+        module.questionsPerSession || 0,
+        moduleIndex
+      ]
+    );
+
+    const questions = Array.isArray(module.questionPool) ? module.questionPool : [];
+    for (let questionIndex = 0; questionIndex < questions.length; questionIndex += 1) {
+      const question = questions[questionIndex];
+      const questionId = question.id || randomUUID();
+
+      await runQuery(
+        `INSERT INTO questions (id, module_id, text, type, feedback_correct, feedback_incorrect, position)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          questionId,
+          moduleId,
+          question.text || "",
+          question.type || "single",
+          question.feedback?.correct || "",
+          question.feedback?.incorrect || "",
+          questionIndex
+        ]
+      );
+
+      const options = Array.isArray(question.options) ? question.options : [];
+      for (let optionIndex = 0; optionIndex < options.length; optionIndex += 1) {
+        const option = options[optionIndex];
+        const optionKey = option.id || randomUUID();
+        const optionId = `${questionId}-${optionKey}`;
+        const isCorrect = (question.correct || []).includes(option.id);
+
+        await runQuery(
+          `INSERT INTO options (id, question_id, label, is_correct, position)
+           VALUES (?, ?, ?, ?, ?)`,
+          [
+            optionId,
+            questionId,
+            option.label || "",
+            isCorrect ? 1 : 0,
+            optionIndex
+          ]
+        );
+      }
+    }
+  }
+}
+
+async function initializeDatabase() {
+  await createSchema();
+  await seedFromFile();
+}
+
+async function getQuizConfig() {
+  const settingsRows = await allQuery("SELECT key, value FROM quiz_settings");
+  const settings = {};
+  settingsRows.forEach(({ key, value }) => {
+    if (key === "strings") {
+      try {
+        settings[key] = JSON.parse(value);
+      } catch (error) {
+        settings[key] = {};
+      }
+    } else {
+      settings[key] = value;
+    }
+  });
+
+  const modules = await allQuery(
+    "SELECT * FROM modules ORDER BY position ASC"
+  );
+
+  const moduleIds = modules.map((module) => module.id);
+  let questions = [];
+  if (moduleIds.length) {
+    questions = await allQuery(
+      `SELECT * FROM questions WHERE module_id IN (${moduleIds
+        .map(() => "?")
+        .join(",")}) ORDER BY position ASC`,
+      moduleIds
+    );
+  }
+
+  const questionIds = questions.map((question) => question.id);
+  let options = [];
+  if (questionIds.length) {
+    options = await allQuery(
+      `SELECT * FROM options WHERE question_id IN (${questionIds
+        .map(() => "?")
+        .join(",")}) ORDER BY position ASC`,
+      questionIds
+    );
+  }
+
+  const optionMap = options.reduce((acc, option) => {
+    if (!acc[option.question_id]) {
+      acc[option.question_id] = [];
+    }
+    acc[option.question_id].push(option);
+    return acc;
+  }, {});
+
+  const questionMap = questions.reduce((acc, question) => {
+    if (!acc[question.module_id]) {
+      acc[question.module_id] = [];
+    }
+    const relatedOptions = optionMap[question.id] || [];
+    acc[question.module_id].push({
+      id: question.id,
+      text: question.text,
+      type: question.type,
+      options: relatedOptions.map((option) => ({
+        id: option.id,
+        label: option.label
+      })),
+      correct: relatedOptions.filter((option) => option.is_correct).map((option) => option.id),
+      feedback: {
+        correct: question.feedback_correct || "",
+        incorrect: question.feedback_incorrect || ""
+      }
+    });
+    return acc;
+  }, {});
+
+  const normalizedModules = modules.map((module) => ({
+    id: module.id,
+    title: module.title,
+    intro: module.intro,
+    tips: JSON.parse(module.tips || "[]"),
+    questionsPerSession: module.questions_per_session,
+    questionPool: questionMap[module.id] || []
+  }));
+
+  return {
+    title: settings.title || "",
+    description: settings.description || "",
+    certificateMessage: settings.certificateMessage || "",
+    strings: settings.strings || {},
+    modules: normalizedModules
+  };
+}
+
+module.exports = {
+  initializeDatabase,
+  getQuizConfig,
+  db,
+  runQuery,
+  getQuery,
+  allQuery
+};

--- a/src/adminQuestions.js
+++ b/src/adminQuestions.js
@@ -1,0 +1,112 @@
+(function () {
+  "use strict";
+
+  function createElement(tag, options = {}) {
+    const element = document.createElement(tag);
+    if (options.className) {
+      element.className = options.className;
+    }
+    if (options.text) {
+      element.textContent = options.text;
+    }
+    if (options.html) {
+      element.innerHTML = options.html;
+    }
+    if (options.attrs) {
+      Object.entries(options.attrs).forEach(([key, value]) => {
+        element.setAttribute(key, value);
+      });
+    }
+    return element;
+  }
+
+  function formatType(type) {
+    if (type === "multiple") {
+      return "Meerdere antwoorden";
+    }
+    return "Eén antwoord";
+  }
+
+  async function fetchQuestions() {
+    const response = await fetch("/api/questions");
+    if (!response.ok) {
+      throw new Error("Kon vragen niet laden");
+    }
+    return response.json();
+  }
+
+  function showFeedback(container, message, variant = "error") {
+    container.innerHTML = "";
+    const box = createElement("div", {
+      className: variant === "error" ? "admin-error" : "admin-success",
+      text: message
+    });
+    container.append(box);
+  }
+
+  function clearFeedback(container) {
+    container.innerHTML = "";
+  }
+
+  function renderQuestions(table, emptyState, questions) {
+    const tbody = table.querySelector("tbody");
+    tbody.innerHTML = "";
+
+    if (!Array.isArray(questions) || !questions.length) {
+      table.hidden = true;
+      emptyState.hidden = false;
+      return;
+    }
+
+    emptyState.hidden = true;
+    table.hidden = false;
+
+    questions.forEach((question) => {
+      const row = document.createElement("tr");
+      const questionCell = createElement("td", {
+        html: `<strong>${question.text}</strong>`
+      });
+
+      const moduleCell = createElement("td", {
+        text: question.moduleTitle || "Onbekende module"
+      });
+
+      const typeCell = createElement("td", {
+        html: `<span class="admin-tag">${formatType(question.type)}</span>`
+      });
+
+      const actionCell = createElement("td");
+      const editLink = createElement("a", {
+        className: "admin-button admin-secondary",
+        text: "Bewerken",
+        attrs: {
+          href: `question-editor.html?id=${encodeURIComponent(question.id)}`
+        }
+      });
+      actionCell.append(editLink);
+
+      row.append(questionCell, moduleCell, typeCell, actionCell);
+      tbody.append(row);
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const table = document.getElementById("questions-table");
+    const emptyState = document.getElementById("questions-empty");
+    const feedback = document.getElementById("questions-feedback");
+
+    fetchQuestions()
+      .then((questions) => {
+        clearFeedback(feedback);
+        renderQuestions(table, emptyState, questions);
+      })
+      .catch((error) => {
+        showFeedback(
+          feedback,
+          error.message || "Er ging iets mis bij het laden van de vragen."
+        );
+        table.hidden = true;
+        emptyState.hidden = false;
+      });
+  });
+})();

--- a/src/digitalSafetyQuiz.js
+++ b/src/digitalSafetyQuiz.js
@@ -5,456 +5,7 @@
     title: "Digitaal Veiligheidsrijbewijs",
     description:
       "Doorloop de modules, beantwoord de vragen en verdien het certificaat voor digitale veiligheid!",
-    modules: [
-      {
-        id: "wachtwoorden",
-        title: "Sterke wachtwoorden",
-        intro:
-          "Een sterk wachtwoord is lang, uniek en bevat cijfers, letters en symbolen. Gebruik geen informatie die andere mensen makkelijk kunnen raden, zoals je naam of verjaardag.",
-        tips: [
-          "Maak wachtwoorden van minimaal 12 tekens",
-          "Gebruik een wachtwoordmanager of een wachtwoordzin",
-          "Deel je wachtwoord nooit met anderen"
-        ],
-        questionsPerSession: 5,
-        questionPool: [
-          {
-            id: "pw-sterkste-wachtwoord",
-            text: "Welk wachtwoord is het veiligst?",
-            type: "single",
-            options: [
-              { id: "a", label: "123456" },
-              { id: "b", label: "voetbal" },
-              { id: "c", label: "H0nd!sPr!ngt" },
-              { id: "d", label: "qwerty" }
-            ],
-            correct: ["c"],
-            feedback: {
-              correct: "Klopt! Dit wachtwoord is lang en gebruikt hoofdletters, cijfers en symbolen.",
-              incorrect: "Niet helemaal. Kies een wachtwoord dat lang is en verschillende soorten tekens gebruikt."
-            }
-          },
-          {
-            id: "pw-onthouden",
-            text: "Wat is een goede manier om een wachtwoord te onthouden?",
-            type: "single",
-            options: [
-              {
-                id: "a",
-                label: "Schrijf het wachtwoord op een briefje en plak het op je scherm."
-              },
-              {
-                id: "b",
-                label: "Gebruik een grappige zin en maak daar een wachtwoord van."
-              },
-              { id: "c", label: "Gebruik hetzelfde wachtwoord voor alles." },
-              { id: "d", label: "Deel het met je beste vriend zodat je het niet vergeet." }
-            ],
-            correct: ["b"],
-            feedback: {
-              correct: "Heel goed! Een wachtwoordzin is makkelijk te onthouden en moeilijk te raden.",
-              incorrect: "Probeer een wachtwoordzin te gebruiken. Dat is veiliger dan overal hetzelfde wachtwoord."
-            }
-          },
-          {
-            id: "pw-manager",
-            text: "Waarom is een wachtwoordmanager handig?",
-            type: "single",
-            options: [
-              {
-                id: "a",
-                label: "Hij maakt automatisch unieke wachtwoorden voor al je accounts."
-              },
-              { id: "b", label: "Hij deelt je wachtwoorden met je vrienden." },
-              { id: "c", label: "Hij verandert je wachtwoorden elke dag zonder te vragen." },
-              { id: "d", label: "Hij onthoudt alleen simpele wachtwoorden." }
-            ],
-            correct: ["a"],
-            feedback: {
-              correct: "Precies! Een wachtwoordmanager maakt unieke wachtwoorden en bewaart ze veilig.",
-              incorrect: "Een wachtwoordmanager helpt je om sterke, unieke wachtwoorden te maken en te bewaren."
-            }
-          },
-          {
-            id: "pw-elk-account",
-            text: "Waarom moet je voor elk account een ander wachtwoord gebruiken?",
-            type: "single",
-            options: [
-              {
-                id: "a",
-                label: "Omdat het anders te veel tijd kost om in te loggen."
-              },
-              {
-                id: "b",
-                label: "Omdat als één wachtwoord wordt gestolen, de andere accounts dan veilig blijven."
-              },
-              { id: "c", label: "Omdat websites dat verplichten." },
-              { id: "d", label: "Omdat korte wachtwoorden niet werken." }
-            ],
-            correct: ["b"],
-            feedback: {
-              correct: "Juist! Zo voorkom je dat iemand meteen overal kan inloggen.",
-              incorrect: "Als één wachtwoord uitlekt kunnen anderen anders al je accounts gebruiken."
-            }
-          },
-          {
-            id: "pw-symbool",
-            text: "Welke combinatie maakt een wachtwoord extra sterk?",
-            type: "single",
-            options: [
-              { id: "a", label: "Alleen kleine letters" },
-              { id: "b", label: "Kleine letters en cijfers" },
-              { id: "c", label: "Hoofdletters, kleine letters, cijfers en symbolen" },
-              { id: "d", label: "Alleen emoji" }
-            ],
-            correct: ["c"],
-            feedback: {
-              correct: "Yes! Hoe meer variatie, hoe moeilijker het is om je wachtwoord te raden.",
-              incorrect: "Gebruik verschillende soorten tekens voor een sterk wachtwoord."
-            }
-          },
-          {
-            id: "pw-waarschuwing",
-            text: "Je krijgt een melding dat een wachtwoord mogelijk is gelekt. Wat doe je?",
-            type: "single",
-            options: [
-              { id: "a", label: "Niets, meldingen zijn nooit belangrijk." },
-              { id: "b", label: "Ik verander meteen het wachtwoord." },
-              { id: "c", label: "Ik deel de melding met vrienden." },
-              { id: "d", label: "Ik verwijder het account." }
-            ],
-            correct: ["b"],
-            feedback: {
-              correct: "Goed gezien! Verander het wachtwoord direct om je account te beschermen.",
-              incorrect: "Reageer op een waarschuwing door het wachtwoord snel te veranderen."
-            }
-          },
-          {
-            id: "pw-twee-stappen",
-            text: "Wat doet tweestapsverificatie (2FA)?",
-            type: "single",
-            options: [
-              { id: "a", label: "Het laat je sneller inloggen." },
-              {
-                id: "b",
-                label: "Het vraagt om een extra bevestiging, zoals een code op je telefoon."
-              },
-              { id: "c", label: "Het maakt je wachtwoord zichtbaar." },
-              { id: "d", label: "Het verwijdert oude wachtwoorden." }
-            ],
-            correct: ["b"],
-            feedback: {
-              correct: "Klopt! Het extra slotje maakt het veel moeilijker om in te breken.",
-              incorrect: "Tweestapsverificatie vraagt om een extra bevestiging voor extra veiligheid."
-            }
-          },
-          {
-            id: "pw-voorbeeld",
-            text: "Welke wachtwoordzin is het sterkst?",
-            type: "single",
-            options: [
-              { id: "a", label: "ikhouvanpizza" },
-              { id: "b", label: "P1zzaIsLekk3r!" },
-              { id: "c", label: "pizzapizza" },
-              { id: "d", label: "12345pizza" }
-            ],
-            correct: ["b"],
-            feedback: {
-              correct: "Lekker bezig! Deze zin is lang en bevat verschillende soorten tekens.",
-              incorrect: "Kies een wachtwoordzin die lang is en cijfers en symbolen gebruikt."
-            }
-          }
-        ]
-      },
-      {
-        id: "delen",
-        title: "Slim delen",
-        intro:
-          "Op internet hoef je niet alles te delen. Denk na voordat je iets plaatst of verstuurt. Vraag jezelf af: zou ik dit ook in de klas laten zien?",
-        tips: [
-          "Plaats geen persoonlijke gegevens zoals adressen of telefoonnummers",
-          "Vraag toestemming voordat je foto's van anderen deelt",
-          "Zet je profiel op privé wanneer mogelijk"
-        ],
-        questionsPerSession: 5,
-        questionPool: [
-          {
-            id: "share-toestemming",
-            text: "Je wilt een leuke foto van een klasgenoot delen. Wat doe je?",
-            type: "single",
-            options: [
-              { id: "a", label: "Ik plaats de foto meteen." },
-              { id: "b", label: "Ik vraag eerst of het mag." },
-              { id: "c", label: "Ik stuur de foto naar iedereen in mijn contacten." },
-              { id: "d", label: "Ik bewerk de foto zodat niemand hem herkent." }
-            ],
-            correct: ["b"],
-            feedback: {
-              correct: "Super! Vraag altijd toestemming voordat je iets deelt wat niet van jou is.",
-              incorrect: "Vraag altijd eerst toestemming voordat je een foto deelt."
-            }
-          },
-          {
-            id: "share-privé",
-            text: "Welke informatie kun je het beste voor jezelf houden?",
-            type: "multiple",
-            options: [
-              { id: "a", label: "Je lievelingskleur" },
-              { id: "b", label: "Je thuisadres" },
-              { id: "c", label: "Je geheime wachtwoord" },
-              { id: "d", label: "Je favoriete dier" }
-            ],
-            correct: ["b", "c"],
-            feedback: {
-              correct: "Goed gedaan! Adressen en wachtwoorden zijn privé.",
-              incorrect: "Denk eraan dat persoonlijke gegevens zoals adressen en wachtwoorden geheim moeten blijven."
-            }
-          },
-          {
-            id: "share-story",
-            text: "Wat controleer je voordat je iets in je story plaatst?",
-            type: "single",
-            options: [
-              { id: "a", label: "Of er persoonlijke informatie zichtbaar is." },
-              { id: "b", label: "Of je genoeg likes krijgt." },
-              { id: "c", label: "Of je vrienden er ook iets op hebben gezet." },
-              { id: "d", label: "Of het filter grappig genoeg is." }
-            ],
-            correct: ["a"],
-            feedback: {
-              correct: "Top! Controleer altijd wat je laat zien voordat je iets deelt.",
-              incorrect: "Kijk of er persoonlijke informatie te zien is voordat je post."
-            }
-          },
-          {
-            id: "share-prive-stand",
-            text: "Waarom is het slim om je account op privé te zetten?",
-            type: "single",
-            options: [
-              { id: "a", label: "Dan kunnen alleen mensen die jij kiest je volgen." },
-              { id: "b", label: "Dan krijg je automatisch meer likes." },
-              { id: "c", label: "Dan hoef je nooit meer een wachtwoord te gebruiken." },
-              { id: "d", label: "Dan verdwijnen oude berichten." }
-            ],
-            correct: ["a"],
-            feedback: {
-              correct: "Juist! Zo bepaal jij wie je berichten kan zien.",
-              incorrect: "Op privé bepalen alleen jouw volgers wat je deelt." }
-          },
-          {
-            id: "share-opinie",
-            text: "Je leest een spannend bericht en wilt het delen. Wat is verstandig?",
-            type: "single",
-            options: [
-              { id: "a", label: "Eerst controleren of het nieuws echt klopt." },
-              { id: "b", label: "Het meteen delen zodat iedereen het ziet." },
-              { id: "c", label: "Alleen de titel lezen en delen." },
-              { id: "d", label: "Een eigen verhaal erbij verzinnen." }
-            ],
-            correct: ["a"],
-            feedback: {
-              correct: "Goed! Controleer bronnen voordat je iets verder verspreidt.",
-              incorrect: "Controleer eerst of het bericht betrouwbaar is voordat je het deelt."
-            }
-          },
-          {
-            id: "share-locatie",
-            text: "Wanneer deel je het beste je locatie op sociale media?",
-            type: "single",
-            options: [
-              { id: "a", label: "Nooit, want locatie is altijd geheim." },
-              { id: "b", label: "Alleen als je zeker weet dat het veilig is en je ouders het goed vinden." },
-              { id: "c", label: "Altijd, zodat iedereen weet waar je bent." },
-              { id: "d", label: "Alleen 's nachts." }
-            ],
-            correct: ["b"],
-            feedback: {
-              correct: "Precies! Wees voorzichtig met het delen van je locatie.",
-              incorrect: "Deel je locatie alleen als je zeker weet dat het veilig is."
-            }
-          },
-          {
-            id: "share-bericht",
-            text: "Iemand vraagt je in een chat om een gênante foto van jezelf. Wat doe je?",
-            type: "single",
-            options: [
-              { id: "a", label: "Ik stuur de foto om aardig te zijn." },
-              { id: "b", label: "Ik maak een grap en stuur toch iets." },
-              { id: "c", label: "Ik stuur niets en vertel het aan een volwassene die ik vertrouw." },
-              { id: "d", label: "Ik vraag andere vrienden wat zij zouden doen en stuur het dan." }
-            ],
-            correct: ["c"],
-            feedback: {
-              correct: "Heel goed! Deel nooit iets waar je je niet prettig bij voelt en vertel het aan een volwassene.",
-              incorrect: "Deel geen gênante foto's en praat met iemand die je vertrouwt."
-            }
-          },
-          {
-            id: "share-reageren",
-            text: "Je ziet een gemene reactie onder een foto van een klasgenoot. Wat kun je doen?",
-            type: "multiple",
-            options: [
-              { id: "a", label: "De reactie melden bij het platform." },
-              { id: "b", label: "Een aardige reactie plaatsen ter ondersteuning." },
-              { id: "c", label: "Zelf ook een gemene reactie plaatsen." },
-              { id: "d", label: "Er met een volwassene over praten." }
-            ],
-            correct: ["a", "b", "d"],
-            feedback: {
-              correct: "Goed dat je het probleem aanpakt en steun geeft!",
-              incorrect: "Meld nare reacties, bied steun en bespreek het met een volwassene."
-            }
-          }
-        ]
-      },
-      {
-        id: "online-vrienden",
-        title: "Online vrienden",
-        intro:
-          "Niet iedereen online is wie hij zegt dat hij is. Wees voorzichtig met nieuwe online vrienden en bespreek vreemde situaties met een volwassene die je vertrouwt.",
-        tips: [
-          "Accepteer geen vriendschapsverzoeken van onbekenden",
-          "Praat met je ouders of leerkracht als iemand je ongemakkelijk laat voelen",
-          "Spreek niet af met iemand die je alleen via internet kent"
-        ],
-        questionsPerSession: 5,
-        questionPool: [
-          {
-            id: "friends-bericht",
-            text: "Wat doe je als iemand die je niet kent je een bericht stuurt?",
-            type: "single",
-            options: [
-              {
-                id: "a",
-                label: "Ik reageer meteen en vertel veel over mezelf."
-              },
-              {
-                id: "b",
-                label: "Ik vertel het aan een volwassene die ik vertrouw."
-              },
-              { id: "c", label: "Ik ga met die persoon afspreken." },
-              { id: "d", label: "Ik stuur mijn telefoonnummer." }
-            ],
-            correct: ["b"],
-            feedback: {
-              correct: "Heel goed! Praat altijd met een volwassene als iemand je iets vreemd vraagt.",
-              incorrect: "Vertel het aan een volwassene die je vertrouwt en reageer niet zomaar."
-            }
-          },
-          {
-            id: "friends-afspraak",
-            text: "Iemand die je online kent vraagt om af te spreken. Wat is verstandig?",
-            type: "single",
-            options: [
-              { id: "a", label: "Ik ga erheen en vertel het niemand." },
-              { id: "b", label: "Ik vertel mijn ouders of leerkracht en ga niet zonder hun toestemming." },
-              { id: "c", label: "Ik neem al mijn vrienden mee." },
-              { id: "d", label: "Ik vraag om een cadeau in ruil voor een ontmoeting." }
-            ],
-            correct: ["b"],
-            feedback: {
-              correct: "Juist! Spreek nooit af zonder toestemming van een volwassene.",
-              incorrect: "Vertel het altijd aan een volwassene en ga niet zomaar naar een afspraak." }
-          },
-          {
-            id: "friends-profiel",
-            text: "Hoe herken je een nepaccount?",
-            type: "single",
-            options: [
-              { id: "a", label: "Er staan weinig foto's of rare berichten op." },
-              { id: "b", label: "Ze hebben altijd heel veel volgers." },
-              { id: "c", label: "Het account is ouder dan een jaar." },
-              { id: "d", label: "Ze gebruiken emoji in hun naam." }
-            ],
-            correct: ["a"],
-            feedback: {
-              correct: "Goed gezien! Nepaccounts hebben vaak weinig echte informatie.",
-              incorrect: "Let op accounts met weinig informatie of vreemde berichten."
-            }
-          },
-          {
-            id: "friends-geheim",
-            text: "Een online vriend vraagt je om jullie gesprekken geheim te houden. Wat doe je?",
-            type: "single",
-            options: [
-              { id: "a", label: "Ik doe wat hij vraagt, want geheimen zijn spannend." },
-              { id: "b", label: "Ik vertel het aan een volwassene die ik vertrouw." },
-              { id: "c", label: "Ik verwijder het gesprek en zeg niets." },
-              { id: "d", label: "Ik stuur een geheim terug." }
-            ],
-            correct: ["b"],
-            feedback: {
-              correct: "Precies! Geheimen online zijn een teken dat je hulp moet vragen.",
-              incorrect: "Vertel het aan een volwassene als iemand je vraagt iets geheim te houden."
-            }
-          },
-          {
-            id: "friends-games",
-            text: "Met wie chat je in een online game?",
-            type: "single",
-            options: [
-              { id: "a", label: "Met iedereen die online is." },
-              { id: "b", label: "Alleen met mensen die ik in het echt ken of die door een volwassene zijn goedgekeurd." },
-              { id: "c", label: "Met mensen die veel prijzen hebben gewonnen." },
-              { id: "d", label: "Met degene die het hardst schreeuwt." }
-            ],
-            correct: ["b"],
-            feedback: {
-              correct: "Goed! Chat alleen met mensen die je vertrouwt of die zijn goedgekeurd.",
-              incorrect: "Blijf bij mensen die je kent of die door een volwassene zijn goedgekeurd."
-            }
-          },
-          {
-            id: "friends-prijs",
-            text: "Je wint zogenaamd een prijs via een chatbericht en moet je gegevens invullen. Wat doe je?",
-            type: "single",
-            options: [
-              { id: "a", label: "Ik geef al mijn gegevens door zodat ik de prijs krijg." },
-              { id: "b", label: "Ik klik op de link en kijk wel wat er gebeurt." },
-              { id: "c", label: "Ik verwijder het bericht en meld het aan een volwassene." },
-              { id: "d", label: "Ik vraag om een grotere prijs." }
-            ],
-            correct: ["c"],
-            feedback: {
-              correct: "Heel goed! Dit kan phishing zijn, dus verwijder het bericht en waarschuw iemand.",
-              incorrect: "Geef geen gegevens door bij verdachte berichten en vertel het aan een volwassene."
-            }
-          },
-          {
-            id: "friends-wachtwoord",
-            text: "Een online vriend vraagt om je wachtwoord zodat hij kan helpen. Wat doe je?",
-            type: "single",
-            options: [
-              { id: "a", label: "Ik geef mijn wachtwoord, want hij lijkt aardig." },
-              { id: "b", label: "Ik bedank hem maar deel mijn wachtwoord niet." },
-              { id: "c", label: "Ik stuur het wachtwoord via een geheime code." },
-              { id: "d", label: "Ik verander mijn wachtwoord en stuur het daarna." }
-            ],
-            correct: ["b"],
-            feedback: {
-              correct: "Precies! Deel je wachtwoord nooit, ook niet met vrienden.",
-              incorrect: "Wachtwoorden zijn altijd privé, deel ze met niemand."
-            }
-          },
-          {
-            id: "friends-gevoel",
-            text: "Iemand online maakt je onzeker of bang. Wat kun je doen?",
-            type: "multiple",
-            options: [
-              { id: "a", label: "Het gesprek stoppen en de persoon blokkeren." },
-              { id: "b", label: "Een volwassene die je vertrouwt om hulp vragen." },
-              { id: "c", label: "Doorgaan met chatten zodat het misschien stopt." },
-              { id: "d", label: "Bewijs bewaren door een screenshot te maken." }
-            ],
-            correct: ["a", "b", "d"],
-            feedback: {
-              correct: "Goed gedaan! Stop het gesprek, bewaar bewijs en zoek hulp.",
-              incorrect: "Stop de chat, blokkeer de persoon, maak een screenshot en vertel het aan een volwassene."
-            }
-          }
-        ]
-      }
-    ],
+    modules: [],
     certificateMessage:
       "Gefeliciteerd! Je hebt alle modules voltooid en toont dat jij veilig en slim online kunt zijn.",
     strings: {
@@ -463,7 +14,7 @@
       continue: "Ga verder",
       checkAnswer: "Controleer antwoord",
       nextQuestion: "Volgende vraag",
-      selectOptions: "Selecteer je antwoord", 
+      selectOptions: "Selecteer je antwoord",
       selectMultiple: "Selecteer een of meer antwoorden",
       feedbackCorrect: "Goed gedaan!",
       feedbackIncorrect: "Probeer het nog eens.",
@@ -474,7 +25,6 @@
       resetButton: "Opnieuw beginnen"
     }
   };
-
   function createElement(tag, options = {}) {
     const el = document.createElement(tag);
     if (options.className) {
@@ -681,12 +231,19 @@
   class DailySessionStore {
     constructor(options = {}) {
       this.prefix = options.prefix || "digitalSafetyQuiz:sessions";
+      this.apiBaseUrl = options.apiBaseUrl || "";
+      this.heartbeatIntervalMs = options.heartbeatIntervalMs || 15000;
       this.database = new IndexedDbAdapter();
       this.storageEnabled = this.database.isSupported;
       this.cache = {};
       this.sessionIndex = {};
+      this.remoteEnabled = typeof fetch === "function";
+      this.remoteSnapshot = null;
+      this._remotePollingTimer = null;
+      this._heartbeatTimers = new Map();
       this._rebuildIndex();
       this._initializeFromDatabase();
+      this._startRemotePolling();
     }
 
     _getDateKey(date = new Date()) {
@@ -727,6 +284,220 @@
         .catch(() => {
           /* stil in geheugen werken */
         });
+    }
+
+    _buildUrl(path = "") {
+      if (!path) {
+        return this.apiBaseUrl || "";
+      }
+      const normalized = path.startsWith("/") ? path : `/${path}`;
+      return `${this.apiBaseUrl || ""}${normalized}`;
+    }
+
+    async _sendRequest(path, options = {}) {
+      if (!this.remoteEnabled) {
+        return null;
+      }
+
+      try {
+        const url = this._buildUrl(path);
+        const fetchOptions = {
+          method: options.method || "GET",
+          credentials: "same-origin"
+        };
+
+        const headers = { ...(options.headers || {}) };
+        if (options.body !== undefined && !headers["Content-Type"]) {
+          headers["Content-Type"] = "application/json";
+        }
+
+        if (Object.keys(headers).length) {
+          fetchOptions.headers = headers;
+        }
+
+        if (options.body !== undefined) {
+          fetchOptions.body = options.body;
+        }
+
+        const response = await fetch(url, fetchOptions);
+        if (!response.ok) {
+          throw new Error(`Request failed: ${response.status}`);
+        }
+
+        const contentType = response.headers.get("content-type") || "";
+        if (
+          response.status === 204 ||
+          !contentType.toLowerCase().includes("application/json")
+        ) {
+          return null;
+        }
+        return response.json();
+      } catch (error) {
+        return null;
+      }
+    }
+
+    _startRemotePolling() {
+      if (!this.remoteEnabled || typeof window === "undefined") {
+        return;
+      }
+
+      if (this._remotePollingTimer) {
+        window.clearInterval(this._remotePollingTimer);
+      }
+
+      const interval = Math.max(this.heartbeatIntervalMs, 10000);
+      this._refreshRemoteSnapshot();
+      this._remotePollingTimer = window.setInterval(() => {
+        this._refreshRemoteSnapshot();
+      }, interval);
+    }
+
+    _normalizeRemoteSnapshot(data) {
+      if (!data || typeof data !== "object") {
+        return null;
+      }
+      const activeSessions = Array.isArray(data.activeSessions)
+        ? data.activeSessions.map((session) => ({
+            id: session.id,
+            name: session.name,
+            correct: Number(session.correct) || 0,
+            incorrect: Number(session.incorrect) || 0,
+            startTime: session.startTime,
+            lastSeen: session.lastSeen
+          }))
+        : [];
+
+      return {
+        dateKey: this._getDateKey(),
+        totals: {
+          correct: Number(data.totalCorrect) || 0,
+          incorrect: Number(data.totalIncorrect) || 0,
+          activeParticipants: Number(data.activeParticipants) || 0
+        },
+        activeSessions,
+        totalSessions: Number(data.totalSessions) || 0
+      };
+    }
+
+    async _refreshRemoteSnapshot() {
+      if (!this.remoteEnabled) {
+        return;
+      }
+      const response = await this._sendRequest("/api/dashboard");
+      if (response) {
+        const normalized = this._normalizeRemoteSnapshot(response);
+        if (normalized) {
+          this.remoteSnapshot = normalized;
+          this._broadcastChange();
+        }
+      }
+    }
+
+    startHeartbeat(sessionId) {
+      if (
+        !sessionId ||
+        !this.remoteEnabled ||
+        typeof window === "undefined"
+      ) {
+        return () => {};
+      }
+
+      this.stopHeartbeat(sessionId);
+
+      const beat = () => {
+        this._sendRequest(`/api/sessions/${sessionId}/heartbeat`, {
+          method: "POST",
+          body: "{}"
+        });
+      };
+
+      beat();
+      const timer = window.setInterval(beat, this.heartbeatIntervalMs);
+      this._heartbeatTimers.set(sessionId, timer);
+
+      return () => {
+        this.stopHeartbeat(sessionId);
+      };
+    }
+
+    stopHeartbeat(sessionId) {
+      if (!sessionId || typeof window === "undefined") {
+        return;
+      }
+      const timer = this._heartbeatTimers.get(sessionId);
+      if (timer) {
+        window.clearInterval(timer);
+        this._heartbeatTimers.delete(sessionId);
+      }
+    }
+
+    markSessionLeft(sessionId, options = {}) {
+      if (!sessionId || !this.remoteEnabled) {
+        return;
+      }
+
+      if (options.useBeacon && typeof navigator !== "undefined") {
+        if (navigator.sendBeacon) {
+          const url = this._buildUrl(`/api/sessions/${sessionId}/leave`);
+          const payload = new Blob(["{}"], {
+            type: "application/json"
+          });
+          navigator.sendBeacon(url, payload);
+        }
+        return;
+      }
+
+      this._sendRequest(`/api/sessions/${sessionId}/leave`, {
+        method: "POST",
+        body: "{}"
+      }).then(() => {
+        this._refreshRemoteSnapshot();
+      });
+    }
+
+    _syncCreateSession(session) {
+      if (!this.remoteEnabled || !session) {
+        return;
+      }
+      this._sendRequest("/api/sessions", {
+        method: "POST",
+        body: JSON.stringify({
+          id: session.id,
+          name: session.name
+        })
+      }).then(() => {
+        this._refreshRemoteSnapshot();
+      });
+    }
+
+    _syncRecordAttempt(sessionId, attempt) {
+      if (!this.remoteEnabled || !sessionId || !attempt) {
+        return;
+      }
+      this._sendRequest(`/api/sessions/${sessionId}/attempt`, {
+        method: "POST",
+        body: JSON.stringify({
+          moduleId: attempt.moduleId,
+          questionId: attempt.questionId,
+          selectedOptionIds: attempt.selectedAnswers || [],
+          isCorrect: Boolean(attempt.isCorrect)
+        })
+      }).then(() => {
+        this._refreshRemoteSnapshot();
+      });
+    }
+
+    _syncCompleteSession(sessionId, summary) {
+      if (!this.remoteEnabled || !sessionId) {
+        return;
+      }
+      this._sendRequest(`/api/sessions/${sessionId}/complete`, {
+        method: "POST",
+        body: JSON.stringify({ summary })
+      }).then(() => {
+        this._refreshRemoteSnapshot();
+      });
     }
 
     _normalizeRecord(record) {
@@ -871,6 +642,7 @@
       };
 
       this._saveByKey(dateKey, { sessions: [session] });
+      this._syncCreateSession(session);
       return session;
     }
 
@@ -899,6 +671,7 @@
 
       session.lastUpdated = new Date().toISOString();
       this._saveByKey(dateKey, data);
+      this._syncRecordAttempt(sessionId, attempt);
       return session;
     }
 
@@ -919,10 +692,14 @@
       session.lastUpdated = session.endTime;
 
       this._saveByKey(dateKey, data);
+      this._syncCompleteSession(sessionId, summary);
       return session;
     }
 
     getSnapshot() {
+      if (this.remoteSnapshot) {
+        return JSON.parse(JSON.stringify(this.remoteSnapshot));
+      }
       const todayKey = this._getDateKey();
       const data = this._readByKey(todayKey);
       const activeSessions = data.sessions.filter(
@@ -1172,6 +949,7 @@
 
   class DigitalSafetyQuiz {
     constructor(options = {}) {
+      this.apiBaseUrl = options.apiBaseUrl || "";
       this.config = normalizeConfig(options.config);
       this.container =
         typeof options.container === "string"
@@ -1182,7 +960,10 @@
           "DigitalSafetyQuiz: kon de container niet vinden. Geef een element of CSS-selector door."
         );
       }
-      this.sessionStore = new DailySessionStore();
+      this.sessionStore = new DailySessionStore({
+        apiBaseUrl: this.apiBaseUrl,
+        heartbeatIntervalMs: options.heartbeatIntervalMs
+      });
       this.sessionModules = [];
       this.sessionId = null;
       this.sessionResults = new Map();
@@ -1191,6 +972,8 @@
       this.currentModuleIndex = -1;
       this.currentQuestionIndex = -1;
       this.score = 0;
+      this.heartbeatStopper = null;
+      this.beforeUnloadHandler = null;
       this.totalQuestions = this._calculateExpectedQuestionCount(
         this.config.modules
       );
@@ -1222,9 +1005,49 @@
       this.renderIntro();
     }
 
+    _attachBeforeUnloadListener() {
+      if (typeof window === "undefined" || this.beforeUnloadHandler) {
+        return;
+      }
+      this.beforeUnloadHandler = () => {
+        if (this.sessionStore && this.sessionId) {
+          this.sessionStore.markSessionLeft(this.sessionId, { useBeacon: true });
+        }
+      };
+      window.addEventListener("beforeunload", this.beforeUnloadHandler);
+    }
+
+    _removeBeforeUnloadListener() {
+      if (typeof window === "undefined" || !this.beforeUnloadHandler) {
+        return;
+      }
+      window.removeEventListener("beforeunload", this.beforeUnloadHandler);
+      this.beforeUnloadHandler = null;
+    }
+
+    _cleanupSessionTracking(markInactive = false) {
+      if (this.heartbeatStopper) {
+        try {
+          this.heartbeatStopper();
+        } catch (error) {
+          /* stil doorgaan */
+        }
+        this.heartbeatStopper = null;
+      } else if (this.sessionStore && this.sessionId) {
+        this.sessionStore.stopHeartbeat(this.sessionId);
+      }
+
+      if (markInactive && this.sessionStore && this.sessionId) {
+        this.sessionStore.markSessionLeft(this.sessionId);
+      }
+
+      this._removeBeforeUnloadListener();
+    }
+
     renderIntro() {
       this.mainEl.innerHTML = "";
       this.footerEl.innerHTML = "";
+      this._cleanupSessionTracking(true);
       this.sessionId = null;
       this.sessionResults = new Map();
       this.participantName = "";
@@ -1303,6 +1126,10 @@
       this.sessionCompleted = false;
       const session = this.sessionStore.createSession(this.participantName);
       this.sessionId = session?.id || null;
+      if (this.sessionStore && this.sessionId && this.sessionStore.startHeartbeat) {
+        this.heartbeatStopper = this.sessionStore.startHeartbeat(this.sessionId);
+      }
+      this._attachBeforeUnloadListener();
 
       this.sessionModules = this._prepareModulesForSession();
       this.totalQuestions = this._calculateExpectedQuestionCount(
@@ -1695,6 +1522,7 @@
       if (!this.sessionCompleted && this.sessionStore && this.sessionId) {
         this.sessionStore.completeSession(this.sessionId, summary);
         this.sessionCompleted = true;
+        this._cleanupSessionTracking(false);
       }
 
       const summaryCard = this.buildSummaryCard(summary);

--- a/src/questionEditor.js
+++ b/src/questionEditor.js
@@ -1,0 +1,258 @@
+(function () {
+  "use strict";
+
+  function $(selector) {
+    return document.querySelector(selector);
+  }
+
+  function createElement(tag, options = {}) {
+    const element = document.createElement(tag);
+    if (options.className) {
+      element.className = options.className;
+    }
+    if (options.text) {
+      element.textContent = options.text;
+    }
+    if (options.attrs) {
+      Object.entries(options.attrs).forEach(([key, value]) => {
+        element.setAttribute(key, value);
+      });
+    }
+    return element;
+  }
+
+  function showFeedback(container, message, variant = "error") {
+    container.innerHTML = "";
+    const box = createElement("div", {
+      className: variant === "error" ? "admin-error" : "admin-success",
+      text: message
+    });
+    container.append(box);
+  }
+
+  function clearFeedback(container) {
+    container.innerHTML = "";
+  }
+
+  function getQueryParam(name) {
+    const params = new URLSearchParams(window.location.search);
+    return params.get(name);
+  }
+
+  async function fetchModules() {
+    const response = await fetch("/api/modules");
+    if (!response.ok) {
+      throw new Error("Kon categorieën niet laden");
+    }
+    return response.json();
+  }
+
+  async function fetchQuestion(id) {
+    const response = await fetch(`/api/questions/${encodeURIComponent(id)}`);
+    if (!response.ok) {
+      throw new Error("Kon vraag niet laden");
+    }
+    return response.json();
+  }
+
+  function createOptionField(optionsList, option = {}) {
+    const wrapper = createElement("div", { className: "admin-option" });
+    const input = createElement("input", {
+      attrs: {
+        type: "text",
+        value: option.label || "",
+        placeholder: "Optietekst",
+        required: "required"
+      }
+    });
+    if (option.id) {
+      input.dataset.optionId = option.id;
+    }
+
+    const checkboxWrapper = createElement("label", {
+      className: "admin-tag"
+    });
+    const checkbox = createElement("input", {
+      attrs: {
+        type: "checkbox",
+        checked: option.isCorrect ? "checked" : undefined
+      }
+    });
+    const checkboxLabel = createElement("span", { text: "Juist" });
+    checkboxWrapper.append(checkbox, checkboxLabel);
+
+    const removeButton = createElement("button", {
+      className: "admin-option-remove",
+      text: "Verwijderen",
+      attrs: { type: "button" }
+    });
+
+    removeButton.addEventListener("click", () => {
+      if (optionsList.children.length <= 2) {
+        showFeedback(
+          $("#editor-feedback"),
+          "Een vraag moet minimaal twee antwoordopties hebben."
+        );
+        return;
+      }
+      optionsList.removeChild(wrapper);
+    });
+
+    wrapper.append(input, checkboxWrapper, removeButton);
+    optionsList.append(wrapper);
+  }
+
+  function readOptions(optionsList) {
+    const items = Array.from(optionsList.querySelectorAll(".admin-option"));
+    return items.map((item) => {
+      const input = item.querySelector("input[type='text']");
+      const checkbox = item.querySelector("input[type='checkbox']");
+      return {
+        id: input.dataset.optionId,
+        label: input.value.trim(),
+        isCorrect: checkbox.checked
+      };
+    });
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    const feedback = $("#editor-feedback");
+    clearFeedback(feedback);
+
+    const moduleSelect = $("#question-module");
+    const textInput = $("#question-text");
+    const typeSelect = $("#question-type");
+    const optionsList = $("#options-list");
+    const feedbackCorrect = $("#feedback-correct");
+    const feedbackIncorrect = $("#feedback-incorrect");
+
+    const options = readOptions(optionsList).filter((option) => option.label);
+
+    if (options.length < 2) {
+      showFeedback(feedback, "Voeg minimaal twee antwoordopties toe.");
+      return;
+    }
+
+    if (!options.some((option) => option.isCorrect)) {
+      showFeedback(feedback, "Markeer minimaal één juist antwoord.");
+      return;
+    }
+
+    const payload = {
+      moduleId: moduleSelect.value,
+      text: textInput.value.trim(),
+      type: typeSelect.value,
+      feedback: {
+        correct: feedbackCorrect.value.trim(),
+        incorrect: feedbackIncorrect.value.trim()
+      },
+      options
+    };
+
+    const questionId = getQueryParam("id");
+    const url = questionId ? `/api/questions/${encodeURIComponent(questionId)}` : "/api/questions";
+    const method = questionId ? "PUT" : "POST";
+
+    const response = await fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      const message = errorData.message || "Opslaan is mislukt.";
+      showFeedback(feedback, message);
+      return;
+    }
+
+    showFeedback(feedback, "Vraag opgeslagen.", "success");
+    setTimeout(() => {
+      window.location.href = "questions.html";
+    }, 800);
+  }
+
+  function populateModules(select, modules, selectedId) {
+    select.innerHTML = "";
+    modules.forEach((module) => {
+      const option = createElement("option", {
+        text: module.title,
+        attrs: { value: module.id }
+      });
+      if (selectedId && selectedId === module.id) {
+        option.selected = true;
+      }
+      select.append(option);
+    });
+  }
+
+  function populateForm(question) {
+    $("#editor-title").textContent = "Vraag bewerken";
+    $("#question-text").value = question.text || "";
+    $("#question-type").value = question.type || "single";
+    $("#feedback-correct").value = question.feedback?.correct || "";
+    $("#feedback-incorrect").value = question.feedback?.incorrect || "";
+
+    const optionsList = $("#options-list");
+    optionsList.innerHTML = "";
+    const options = Array.isArray(question.options) && question.options.length
+      ? question.options
+      : [{}, {}];
+    options.forEach((option) => createOptionField(optionsList, option));
+  }
+
+  document.addEventListener("DOMContentLoaded", async () => {
+    const feedback = $("#editor-feedback");
+    const optionsList = $("#options-list");
+    const addButton = $("#add-option");
+    const cancelButton = $("#cancel-button");
+    const form = $("#question-form");
+    const moduleSelect = $("#question-module");
+
+    let modules = [];
+    try {
+      modules = await fetchModules();
+      populateModules(moduleSelect, modules, null);
+    } catch (error) {
+      showFeedback(feedback, error.message || "Kon de categorieën niet laden.");
+      return;
+    }
+
+    const questionId = getQueryParam("id");
+    if (questionId) {
+      try {
+        const question = await fetchQuestion(questionId);
+        populateModules(moduleSelect, modules, question.moduleId);
+        populateForm(question);
+      } catch (error) {
+        showFeedback(
+          feedback,
+          error.message || "Kon de vraaggegevens niet laden."
+        );
+        return;
+      }
+    } else {
+      optionsList.innerHTML = "";
+      createOptionField(optionsList, {});
+      createOptionField(optionsList, {});
+    }
+
+    addButton.addEventListener("click", () => {
+      createOptionField(optionsList, {});
+    });
+
+    cancelButton.addEventListener("click", () => {
+      window.location.href = "questions.html";
+    });
+
+    form.addEventListener("submit", (event) => {
+      handleSubmit(event).catch((error) => {
+        showFeedback(
+          feedback,
+          error.message || "Er is een fout opgetreden tijdens het opslaan."
+        );
+      });
+    });
+  });
+})();

--- a/styles/admin.css
+++ b/styles/admin.css
@@ -1,0 +1,167 @@
+body {
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  margin: 0;
+  background: #f5f7fb;
+  color: #1f2937;
+}
+
+.admin-container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.admin-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.admin-card {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  padding: 1.5rem;
+}
+
+.admin-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 1.2rem;
+  background: #2563eb;
+  color: #ffffff;
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: background 0.2s ease;
+}
+
+.admin-button:hover {
+  background: #1d4ed8;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.admin-table thead {
+  text-align: left;
+  font-size: 0.95rem;
+  color: #6b7280;
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.admin-table tbody tr:hover {
+  background: #f9fafb;
+}
+
+.admin-empty {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: #6b7280;
+}
+
+.admin-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  background: #eff6ff;
+  color: #2563eb;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.admin-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.admin-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.admin-field label {
+  font-weight: 600;
+  color: #374151;
+}
+
+.admin-field input[type="text"],
+.admin-field textarea,
+.admin-field select {
+  padding: 0.65rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 1rem;
+}
+
+.admin-options {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.admin-option {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.admin-option input[type="text"] {
+  width: 100%;
+}
+
+.admin-option-remove {
+  background: transparent;
+  border: none;
+  color: #dc2626;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.admin-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.admin-secondary {
+  background: #f3f4f6;
+  color: #1f2937;
+}
+
+.admin-error {
+  background: #fee2e2;
+  color: #991b1b;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+}
+
+.admin-success {
+  background: #dcfce7;
+  color: #166534;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+}
+
+@media (max-width: 640px) {
+  .admin-option {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add an Express/SQLite backend with REST endpoints for quiz config, session tracking, and dashboard metrics
- seed the database from a JSON data set and update the quiz client to fetch configuration and sync attempts/heartbeats with the server
- add question management pages with reusable styles and document how to run the new server locally

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e10de4bf9c8323bbce49a5621ccec0