### PR TITLE
Fix frontend API requests to respect current base path

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -15,7 +15,17 @@
     <script src="../src/quizDashboard.js"></script>
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        createDigitalSafetyDashboard({ container: "#dashboard" });
+        const baseUrl = new URL("./", window.location.href);
+        const apiBasePath = baseUrl.pathname.replace(/\/$/, "");
+
+        if (!window.__CHAT_SPEL_API_BASE_PATH__) {
+          window.__CHAT_SPEL_API_BASE_PATH__ = apiBasePath;
+        }
+
+        createDigitalSafetyDashboard({
+          container: "#dashboard",
+          apiBaseUrl: apiBasePath
+        });
       });
     </script>
   </body>

--- a/public/index.html
+++ b/public/index.html
@@ -21,8 +21,18 @@
           container.textContent = "Quiz wordt geladen...";
         }
 
+        const baseUrl = new URL("./", window.location.href);
+        const apiBasePath = baseUrl.pathname.replace(/\/$/, "");
+        if (!window.__CHAT_SPEL_API_BASE_PATH__) {
+          window.__CHAT_SPEL_API_BASE_PATH__ = apiBasePath;
+        }
+        const buildApiUrl = (path) => {
+          const normalized = path.startsWith("/") ? path.slice(1) : path;
+          return new URL(normalized, baseUrl).toString();
+        };
+
         try {
-          const response = await fetch("/api/quiz-config");
+          const response = await fetch(buildApiUrl("api/quiz-config"));
           if (!response.ok) {
             throw new Error("Kon configuratie niet laden");
           }
@@ -30,7 +40,7 @@
           new DigitalSafetyQuiz({
             container: "#quiz",
             config,
-            apiBaseUrl: ""
+            apiBaseUrl: apiBasePath
           });
         } catch (error) {
           if (container) {

--- a/src/adminQuestions.js
+++ b/src/adminQuestions.js
@@ -1,6 +1,19 @@
 (function () {
   "use strict";
 
+  const API_BASE = new URL("./", window.location.href);
+
+  function getApiBasePath() {
+    return API_BASE.pathname.replace(/\/$/, "");
+  }
+
+  function buildApiUrl(path) {
+    const normalized = typeof path === "string" && path.startsWith("/")
+      ? path.slice(1)
+      : path || "";
+    return new URL(normalized, API_BASE).toString();
+  }
+
   function createElement(tag, options = {}) {
     const element = document.createElement(tag);
     if (options.className) {
@@ -28,7 +41,7 @@
   }
 
   async function fetchQuestions() {
-    const response = await fetch("/api/questions");
+    const response = await fetch(buildApiUrl("api/questions"));
     if (!response.ok) {
       throw new Error("Kon vragen niet laden");
     }
@@ -94,6 +107,11 @@
     const table = document.getElementById("questions-table");
     const emptyState = document.getElementById("questions-empty");
     const feedback = document.getElementById("questions-feedback");
+
+    // Zorg dat de API-basis ook beschikbaar is voor andere scripts indien nodig.
+    if (!window.__CHAT_SPEL_API_BASE_PATH__) {
+      window.__CHAT_SPEL_API_BASE_PATH__ = getApiBasePath();
+    }
 
     fetchQuestions()
       .then((questions) => {

--- a/src/questionEditor.js
+++ b/src/questionEditor.js
@@ -1,6 +1,19 @@
 (function () {
   "use strict";
 
+  const API_BASE = new URL("./", window.location.href);
+
+  function getApiBasePath() {
+    return API_BASE.pathname.replace(/\/$/, "");
+  }
+
+  function buildApiUrl(path) {
+    const normalized = typeof path === "string" && path.startsWith("/")
+      ? path.slice(1)
+      : path || "";
+    return new URL(normalized, API_BASE).toString();
+  }
+
   function $(selector) {
     return document.querySelector(selector);
   }
@@ -40,7 +53,7 @@
   }
 
   async function fetchModules() {
-    const response = await fetch("/api/modules");
+    const response = await fetch(buildApiUrl("api/modules"));
     if (!response.ok) {
       throw new Error("Kon categorieën niet laden");
     }
@@ -48,7 +61,9 @@
   }
 
   async function fetchQuestion(id) {
-    const response = await fetch(`/api/questions/${encodeURIComponent(id)}`);
+    const response = await fetch(
+      buildApiUrl(`api/questions/${encodeURIComponent(id)}`)
+    );
     if (!response.ok) {
       throw new Error("Kon vraag niet laden");
     }
@@ -151,7 +166,9 @@
     };
 
     const questionId = getQueryParam("id");
-    const url = questionId ? `/api/questions/${encodeURIComponent(questionId)}` : "/api/questions";
+    const url = questionId
+      ? buildApiUrl(`api/questions/${encodeURIComponent(questionId)}`)
+      : buildApiUrl("api/questions");
     const method = questionId ? "PUT" : "POST";
 
     const response = await fetch(url, {
@@ -209,6 +226,10 @@
     const cancelButton = $("#cancel-button");
     const form = $("#question-form");
     const moduleSelect = $("#question-module");
+
+    if (!window.__CHAT_SPEL_API_BASE_PATH__) {
+      window.__CHAT_SPEL_API_BASE_PATH__ = getApiBasePath();
+    }
 
     let modules = [];
     try {


### PR DESCRIPTION
## Summary
- derive the API base path from the current page so the quiz uses the correct API endpoints when served from a subdirectory
- update the dashboard and admin pages to share the same resolved API base path for their fetch requests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1193002f4832383364149885969f1