### PR TITLE
Fix admin API base path resolution and hover styling

### DIFF
--- a/src/adminQuestions.js
+++ b/src/adminQuestions.js
@@ -1,17 +1,32 @@
 (function () {
   "use strict";
 
-  const API_BASE = new URL("./", window.location.href);
+  const PAGE_BASE = new URL("./", window.location.href);
+
+  function normalizeBasePath(path) {
+    if (!path || path === "/") {
+      return "";
+    }
+    return path.replace(/\/+$/, "");
+  }
 
   function getApiBasePath() {
-    return API_BASE.pathname.replace(/\/$/, "");
+    if (typeof window.__CHAT_SPEL_API_BASE_PATH__ === "string") {
+      return normalizeBasePath(window.__CHAT_SPEL_API_BASE_PATH__);
+    }
+    return normalizeBasePath(PAGE_BASE.pathname);
+  }
+
+  function getApiBaseUrl() {
+    const basePath = getApiBasePath();
+    const normalized = basePath ? `${basePath}/` : "";
+    return new URL(normalized, PAGE_BASE.origin);
   }
 
   function buildApiUrl(path) {
-    const normalized = typeof path === "string" && path.startsWith("/")
-      ? path.slice(1)
-      : path || "";
-    return new URL(normalized, API_BASE).toString();
+    const base = getApiBaseUrl();
+    const normalized = (path || "").toString().replace(/^\/+/, "");
+    return new URL(normalized, base).toString();
   }
 
   function createElement(tag, options = {}) {

--- a/src/questionEditor.js
+++ b/src/questionEditor.js
@@ -1,17 +1,32 @@
 (function () {
   "use strict";
 
-  const API_BASE = new URL("./", window.location.href);
+  const PAGE_BASE = new URL("./", window.location.href);
+
+  function normalizeBasePath(path) {
+    if (!path || path === "/") {
+      return "";
+    }
+    return path.replace(/\/+$/, "");
+  }
 
   function getApiBasePath() {
-    return API_BASE.pathname.replace(/\/$/, "");
+    if (typeof window.__CHAT_SPEL_API_BASE_PATH__ === "string") {
+      return normalizeBasePath(window.__CHAT_SPEL_API_BASE_PATH__);
+    }
+    return normalizeBasePath(PAGE_BASE.pathname);
+  }
+
+  function getApiBaseUrl() {
+    const basePath = getApiBasePath();
+    const normalized = basePath ? `${basePath}/` : "";
+    return new URL(normalized, PAGE_BASE.origin);
   }
 
   function buildApiUrl(path) {
-    const normalized = typeof path === "string" && path.startsWith("/")
-      ? path.slice(1)
-      : path || "";
-    return new URL(normalized, API_BASE).toString();
+    const base = getApiBaseUrl();
+    const normalized = (path || "").toString().replace(/^\/+/, "");
+    return new URL(normalized, base).toString();
   }
 
   function $(selector) {

--- a/styles/admin.css
+++ b/styles/admin.css
@@ -141,6 +141,11 @@ body {
   color: #1f2937;
 }
 
+.admin-button.admin-secondary:hover {
+  background: #1f2937;
+  color: #ffffff;
+}
+
 .admin-error {
   background: #fee2e2;
   color: #991b1b;


### PR DESCRIPTION
## Summary
- normalize the admin API base path detection so questions and modules load from the correct backend URL
- ensure the question editor uses the same base URL logic so option creation works and responses sync to the database
- update the secondary admin button hover state to switch the text to white for better contrast

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e14d62a8b08323b80bfb54661c8e09