### PR TITLE
Enforce Google Sheets as sole configuration source

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Maak in het spreadsheet minimaal de volgende tabbladen aan:
 - **questions** – kolommen `id`, `moduleId`, `text`, `type`, `feedbackCorrect`, `feedbackIncorrect` en `position`.
 - **options** – kolommen `id`, `questionId`, `label`, `isCorrect` (TRUE/FALSE) en `position`.
 
-Pas je iets aan in het spreadsheet, dan is de wijziging direct zichtbaar in de quiz zonder dat je code hoeft te deployen.
+Pas je iets aan in het spreadsheet, dan is de wijziging direct zichtbaar in de quiz zonder dat je code hoeft te deployen. Als de configuratie niet kan worden geladen, verschijnt er een foutmelding op de pagina en in de browserconsole; er is geen automatische terugval meer naar de meegeleverde JSON-bestanden. Hierdoor blijft Google Sheets de enige bron van waarheid.
 
 Let op: voor de downloadknop van het certificaat heb je de bibliotheek [`html2canvas`](https://html2canvas.hertzen.com/) nodig. Voeg deze toe vóór `digitalSafetyQuiz.js` als je de downloadfunctie wilt gebruiken.
 

--- a/public/index.html
+++ b/public/index.html
@@ -74,34 +74,6 @@
             window.DSQGoogleSheets.DEFAULT_SHEET_ID;
         }
 
-        const fallbackUrls = [
-          "../data/quizData.json",
-          "./data/quizData.json",
-          new URL("/data/quizData.json", window.location.origin).toString()
-        ].map((path) => new URL(path, pageBaseUrl).toString());
-
-        const uniqueUrls = (urls) => {
-          const seen = new Set();
-          return urls.filter((url) => {
-            if (seen.has(url)) {
-              return false;
-            }
-            seen.add(url);
-            return true;
-          });
-        };
-
-        const fetchJson = async (url) => {
-          const response = await fetch(url, {
-            credentials: "same-origin",
-            cache: "no-store"
-          });
-          if (!response.ok) {
-            throw new Error(`Kon configuratie niet laden: ${response.status}`);
-          }
-          return response.json();
-        };
-
         const loadConfigFromSheets = async () => {
           if (
             !window.DSQGoogleSheets ||
@@ -122,19 +94,6 @@
         }
 
         if (!config) {
-          for (const url of uniqueUrls(fallbackUrls)) {
-            try {
-              config = await fetchJson(url);
-              if (config) {
-                break;
-              }
-            } catch (error) {
-              loadErrors.push(error);
-            }
-          }
-        }
-
-        if (!config) {
           if (container) {
             container.textContent =
               "De quiz kon niet worden geladen. Controleer je Google Sheet configuratie.";
@@ -145,6 +104,15 @@
             });
           }
           return;
+        }
+
+        if (!sessionApiBaseUrl && window.console) {
+          const { warn } = window.console;
+          if (typeof warn === "function") {
+            warn(
+              "DigitalSafetyQuiz: er is geen session API base URL ingesteld. Sessiedata wordt alleen lokaal in de browser opgeslagen."
+            );
+          }
         }
 
         try {


### PR DESCRIPTION
## Summary
- remove the local JSON configuration fallback so the quiz only loads data from Google Sheets
- surface a console warning when no session API base URL is configured to flag missing Google Sheets session storage
- document that there is no automatic fallback, keeping Google Sheets as the single source of truth

## Testing
- npm test *(fails: jest command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e16b874e6c83239044dcb8c1775424