### PR TITLE
Expose defaults config on window and verify strings

### DIFF
--- a/src/googleSheetsConfigClient.js
+++ b/src/googleSheetsConfigClient.js
@@ -355,6 +355,22 @@
     }, {});
   }
 
+  function setDebugDefaults(dataset, defaults, strings) {
+    if (!dataset || typeof global !== "object" || !global) {
+      return;
+    }
+    try {
+      const snapshot = {
+        raw: deepClone(dataset.defaults),
+        normalized: deepClone(defaults),
+        strings: deepClone(strings)
+      };
+      global.__CHAT_SPEL_DEFAULTS_CONFIG__ = snapshot;
+    } catch (error) {
+      // stille debug: als deepClone faalt willen we geen fout gooien
+    }
+  }
+
   function buildQuizConfigFromDataset(dataset) {
     const defaults = normalizeDefaults(dataset.defaults);
     const modules = (dataset.modules || []).map(buildModule);
@@ -367,11 +383,14 @@
       questionsWithOptions
     );
 
+    const strings = normalizeStrings(defaults.strings);
+    setDebugDefaults(dataset, defaults, strings);
+
     return {
       title: defaults.title || "",
       description: defaults.description || "",
       certificateMessage: defaults.certificateMessage || "",
-      strings: normalizeStrings(defaults.strings),
+      strings,
       modules: modulesWithQuestions,
       sessionApiBaseUrl: resolveSessionApiBaseUrl(defaults),
       dashboard: resolveDashboardSettings(defaults)
@@ -380,6 +399,8 @@
 
   function buildSessionSettings(dataset) {
     const defaults = normalizeDefaults(dataset.defaults);
+    const strings = normalizeStrings(defaults.strings);
+    setDebugDefaults(dataset, defaults, strings);
     return {
       sessionApiBaseUrl: resolveSessionApiBaseUrl(defaults),
       dashboard: resolveDashboardSettings(defaults)

--- a/tests/googleSheetsConfigClient.test.js
+++ b/tests/googleSheetsConfigClient.test.js
@@ -31,6 +31,17 @@ describe("googleSheetsConfigClient", () => {
     );
     expect(config.dashboard.refreshIntervalMs).toBe(20000);
     expect(config.dashboard.autoUpdate).toBe(false);
+    expect(config.strings.startButton).toBe("Start de quiz");
+    expect(config.strings.checkAnswer).toBe("Controleer antwoord");
+
+    expect(global.__CHAT_SPEL_DEFAULTS_CONFIG__).toMatchObject({
+      normalized: expect.objectContaining({
+        title: "Digitaal Veiligheidsrijbewijs"
+      }),
+      strings: expect.objectContaining({
+        startButton: "Start de quiz"
+      })
+    });
   });
 
   test("leest sessie-instellingen uit defaults", async () => {


### PR DESCRIPTION
## Summary
- expose the normalized defaults configuration on `window.__CHAT_SPEL_DEFAULTS_CONFIG__` for debugging
- reuse the normalized strings from defaults and share them with the debug snapshot
- extend the Google Sheets client tests to cover defaults strings and the debug snapshot

## Testing
- npm test -- googleSheetsConfigClient.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e187136df08323b8fcd3737ef5969d