### PR TITLE
Add PostgreSQL connection support via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,53 @@ Deze repository bevat een kant-en-klare quizmodule die je kunt insluiten op bijv
 - `styles/digitalSafetyQuiz.css` – Stijlen voor de quiz.
 - `public/index.html` – Voorbeeldpagina om de quiz lokaal te bekijken/testen.
 
-## Lokaal testen
+## Installatie & lokaal testen
 
-Installeer eerst de afhankelijkheden en start daarna de Node-server. De server levert de quizbestanden, API's en beheerschermen uit.
+1. Kopieer de repository naar je eigen machine en installeer de afhankelijkheden:
 
-```bash
-npm install
-npm start
-```
+   ```bash
+   npm install
+   ```
 
-Open vervolgens [http://localhost:3000/](http://localhost:3000/) in je browser om de quiz te bekijken. Het live dashboard is bereikbaar via `public/dashboard.html` en het beheer van vragen via `public/questions.html`.
+2. Maak optioneel een `.env`-bestand in de hoofdmap om lokale instellingen te overschrijven (zie [Configuratie](#configuratie)).
+
+3. Start de server:
+
+   ```bash
+   npm start
+   ```
+
+4. Open vervolgens [http://localhost:3000/](http://localhost:3000/) in je browser om de quiz te bekijken. Het live dashboard is bereikbaar via `public/dashboard.html` en het beheer van vragen via `public/questions.html`.
+
+Tijdens ontwikkeling kun je ook `npm run dev` gebruiken voor automatische herstart bij codewijzigingen.
+
+## Configuratie
+
+De server leest instellingen uit environment-variabelen. Plaats ze lokaal in een `.env`-bestand en configureer ze op Render via het **Environment**-tabblad.
+
+| Variabele | Beschrijving | Standaard |
+| --- | --- | --- |
+| `PORT` | Poort waarop de server draait. | `3000` |
+| `DATABASE_URL` | Connection string naar een externe PostgreSQL-database (bijvoorbeeld Render). Als deze waarde is gezet, gebruikt de app PostgreSQL in plaats van de meegeleverde SQLite-database. | *(niet gezet)* |
+| `DATABASE_SSL` | Zet deze op `false` om SSL uit te schakelen voor PostgreSQL. Laat leeg (of `true`) om SSL te gebruiken; Render vereist dit meestal. | `true` |
+| `SQLITE_DATABASE_PATH` | Pad naar een alternatief SQLite-bestand als je geen PostgreSQL gebruikt. | `data/quiz.db` |
+| `SESSION_TIMEOUT_MS` | Bepaalt hoe lang een sessie actief blijft zonder hartslag (dashboard). | `60000` |
+
+### Verbinding maken met een Render-database
+
+1. Maak in Render een **PostgreSQL**-database aan en kopieer de `External Database URL`.
+2. Voeg in de Render-service van deze app de volgende environment-variabelen toe:
+
+   ```
+   DATABASE_URL=postgres://gebruikersnaam:password@host:port/dbname?sslmode=require
+   DATABASE_SSL=true
+   ```
+
+   Laat `DATABASE_SSL` op `true` staan om het zelfondertekende certificaat van Render te accepteren. Pas de waarde alleen aan als je een eigen certificaat beheert.
+
+3. Deploy de service opnieuw. Bij de eerste start wordt de database automatisch voorzien van de tabellen en de standaard quizinhoud vanuit `data/quizData.json`.
+
+Wil je lokaal dezelfde Render-database gebruiken? Maak dan een `.env`-bestand met dezelfde `DATABASE_URL` en `DATABASE_SSL=true`.
 
 ### Vragen beheren
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "pg": "^8.11.5",
         "sqlite3": "^5.1.6"
       },
       "devDependencies": {
@@ -1834,6 +1835,95 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1845,6 +1935,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -2340,6 +2469,15 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sqlite3": {
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
@@ -2653,6 +2791,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "pg": "^8.11.5",
     "sqlite3": "^5.1.6"
   },
   "devDependencies": {

--- a/server/database.js
+++ b/server/database.js
@@ -1,11 +1,69 @@
+require("dotenv").config();
+
 const path = require("path");
 const sqlite3 = require("sqlite3").verbose();
+const { Pool } = require("pg");
 
-const dbPath = path.join(__dirname, "..", "data", "quiz.db");
-const db = new sqlite3.Database(dbPath);
+const DATABASE_URL = process.env.DATABASE_URL;
+const shouldUsePostgres = Boolean(DATABASE_URL);
 
-db.serialize(() => {
-  db.run("PRAGMA foreign_keys = ON");
+function mapPlaceholders(query = "") {
+  let index = 0;
+  return query.replace(/\?/g, () => {
+    index += 1;
+    return `$${index}`;
+  });
+}
+
+if (shouldUsePostgres) {
+  const shouldUseSSL = process.env.DATABASE_SSL !== "false";
+  const pool = new Pool({
+    connectionString: DATABASE_URL,
+    ssl: shouldUseSSL ? { rejectUnauthorized: false } : undefined
+  });
+
+  module.exports = {
+    isPostgres: true,
+    run(query, params = [], callback = () => {}) {
+      pool
+        .query(mapPlaceholders(query), params)
+        .then((result) => {
+          const context = { lastID: null, changes: result.rowCount };
+          callback.call(context, null);
+        })
+        .catch((error) => callback(error));
+    },
+    get(query, params = [], callback = () => {}) {
+      pool
+        .query(mapPlaceholders(query), params)
+        .then((result) => callback(null, result.rows[0] || undefined))
+        .catch((error) => callback(error));
+    },
+    all(query, params = [], callback = () => {}) {
+      pool
+        .query(mapPlaceholders(query), params)
+        .then((result) => callback(null, result.rows))
+        .catch((error) => callback(error));
+    },
+    close(callback = () => {}) {
+      pool
+        .end()
+        .then(() => callback(null))
+        .catch((error) => callback(error));
+    }
+  };
+}
+
+const dbPath = process.env.SQLITE_DATABASE_PATH
+  ? path.resolve(process.env.SQLITE_DATABASE_PATH)
+  : path.join(__dirname, "..", "data", "quiz.db");
+
+const sqliteDb = new sqlite3.Database(dbPath);
+
+sqliteDb.serialize(() => {
+  sqliteDb.run("PRAGMA foreign_keys = ON");
 });
 
-module.exports = db;
+sqliteDb.isPostgres = false;
+
+module.exports = sqliteDb;

--- a/server/index.js
+++ b/server/index.js
@@ -304,10 +304,12 @@ app.post(
       req.body || {};
 
     const now = new Date().toISOString();
+    const attemptId = randomUUID();
     await runQuery(
-      `INSERT INTO session_attempts (session_id, module_id, question_id, selected_options, is_correct, answered_at)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO session_attempts (id, session_id, module_id, question_id, selected_options, is_correct, answered_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
       [
+        attemptId,
         id,
         moduleId || null,
         questionId || null,

--- a/server/initializeDatabase.js
+++ b/server/initializeDatabase.js
@@ -96,7 +96,7 @@ async function createSchema() {
 
   await runQuery(`
     CREATE TABLE IF NOT EXISTS session_attempts (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      id TEXT PRIMARY KEY,
       session_id TEXT NOT NULL,
       module_id TEXT,
       question_id TEXT,
@@ -234,10 +234,9 @@ async function getQuizConfig() {
   const questionIds = questions.map((question) => question.id);
   let options = [];
   if (questionIds.length) {
+    const placeholderList = questionIds.map(() => "?").join(",");
     options = await allQuery(
-      `SELECT * FROM options WHERE question_id IN (${questionIds
-        .map(() => "?")
-        .join(",")}) ORDER BY position ASC`,
+      `SELECT * FROM options WHERE question_id IN (${placeholderList}) ORDER BY position ASC`,
       questionIds
     );
   }


### PR DESCRIPTION
## Summary
- allow the backend to switch between SQLite and PostgreSQL based on environment variables for Render deployments
- update session attempt handling and documentation to work with UUID primary keys across database engines
- document installation steps and environment configuration, including Render database setup guidance

## Testing
- npm install
- node - <<'NODE'
const { initializeDatabase } = require('./server/initializeDatabase');
initializeDatabase()
  .then(() => {
    console.log('initialized');
    process.exit(0);
  })
  .catch((err) => {
    console.error(err);
    process.exit(1);
  });
NODE


------
https://chatgpt.com/codex/tasks/task_e_68e22dd574d8832384864227ae47ce10