### PR TITLE
Add daily attempt stats to database overview

### DIFF
--- a/src/adminQuestions.js
+++ b/src/adminQuestions.js
@@ -48,6 +48,19 @@
     container.innerHTML = "";
   }
 
+  function resolveModuleTitle(question) {
+    if (!question || typeof question !== "object") {
+      return "Onbekende module";
+    }
+
+    return (
+      question.moduleTitle ||
+      question.module_title ||
+      question.moduletitle ||
+      "Onbekende module"
+    );
+  }
+
   function renderQuestions(table, emptyState, questions) {
     const tbody = table.querySelector("tbody");
     tbody.innerHTML = "";
@@ -68,7 +81,7 @@
       });
 
       const moduleCell = createElement("td", {
-        text: question.moduleTitle || "Onbekende module"
+        text: resolveModuleTitle(question)
       });
 
       const typeCell = createElement("td", {

--- a/styles/digitalSafetyQuiz.css
+++ b/styles/digitalSafetyQuiz.css
@@ -238,6 +238,7 @@
   border: 2px solid #cbd5f5;
   margin-top: 1rem;
   font-size: 1rem;
+  box-sizing: border-box;
 }
 
 .dsq-input:focus {
@@ -543,5 +544,21 @@
   color: #b91c1c;
   border-radius: 12px;
   padding: 0.75rem 1rem;
+}
+
+.database-overview__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.database-overview__heading {
+  font-size: 1.15rem;
+  color: #0f172a;
+}
+
+.database-overview__date {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- aggregate per-day quiz attempt metrics in the database-info API for both PostgreSQL and SQLite
- render daily performance alongside category totals on the database overview page
- adjust styling so the participant name input stays within the layout and add styles for the new tables

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e28607609c8323bd342cb6d91815cd