### PR TITLE
Allow configuring API base URL for embedded quiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ Ga naar [http://localhost:3000/questions.html](http://localhost:3000/questions.h
   rel="stylesheet"
   href="https://jouw-domein.nl/path/to/digitalSafetyQuiz.css"
 />
-<script src="https://jouw-domein.nl/path/to/digitalSafetyQuiz.js"></script>
+<script
+  src="https://jouw-domein.nl/path/to/digitalSafetyQuiz.js"
+  data-api-base-url="https://jouw-backend.nl"
+></script>
 <script>
   document.addEventListener("DOMContentLoaded", function () {
     new DigitalSafetyQuiz({
@@ -82,6 +85,22 @@ Ga naar [http://localhost:3000/questions.html](http://localhost:3000/questions.h
     });
   });
 </script>
+```
+
+De `data-api-base-url` geeft aan waar de server draait die de API aanbiedt (bijvoorbeeld
+een Render-service). Gebruik hierbij het domein of basispad waar de API beschikbaar is;
+de quiz voegt zelf `/api/...` toe aan de requests. Deze URL wordt automatisch gebruikt
+voor het versturen van heartbeat- en sessieverkeer, zodat het insluiten op een extern
+domein (zoals Wix) correct blijft werken. Je kunt het basispad ook op een later moment
+instellen via JavaScript:
+
+```html
+<script>
+  window.DigitalSafetyQuizDefaults = {
+    apiBaseUrl: "https://jouw-backend.nl"
+  };
+</script>
+<script src="https://jouw-domein.nl/path/to/digitalSafetyQuiz.js"></script>
 ```
 
 ### Configuratie aanpassen


### PR DESCRIPTION
## Summary
- allow the quiz runtime to derive its API base URL from constructor options, global defaults, or script data attributes so embeds can call the hosted backend
- expand the Wix embed instructions with guidance on using the `data-api-base-url` attribute or global defaults to point to the backend service

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e28f6aac9c8323af427573b87e3ed4