### PR TITLE
Add category management page with active toggles and shared menu

### DIFF
--- a/public/categories.html
+++ b/public/categories.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vraag bewerken</title>
+    <title>Categoriebeheer</title>
     <link rel="stylesheet" href="../styles/admin.css" />
   </head>
-  <body data-admin-page="questions">
+  <body data-admin-page="categories">
     <main class="admin-container">
       <header class="admin-header">
         <div class="admin-title-group">
@@ -30,46 +30,57 @@
               <a class="admin-menu-link" href="dashboard.html" data-page="dashboard">Live dashboard</a>
             </nav>
           </div>
-          <h1 id="editor-title">Nieuwe vraag</h1>
+          <h1>Categoriebeheer</h1>
         </div>
-        <a class="admin-button admin-secondary" href="questions.html">Terug naar overzicht</a>
+        <button class="admin-button" type="button" id="category-new">
+          Nieuwe categorie
+        </button>
       </header>
+
       <section class="admin-card">
-        <div id="editor-feedback"></div>
-        <form class="admin-form" id="question-form">
+        <div id="categories-feedback"></div>
+        <table class="admin-table" id="categories-table" hidden>
+          <thead>
+            <tr>
+              <th>Categorie</th>
+              <th>Vragen per sessie</th>
+              <th>Status</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <div class="admin-empty" id="categories-empty" hidden>
+          Nog geen categorieën gevonden.
+        </div>
+      </section>
+
+      <section class="admin-card">
+        <h2 id="category-form-title">Nieuwe categorie</h2>
+        <div id="category-form-feedback"></div>
+        <form class="admin-form" id="category-form">
           <div class="admin-field">
-            <label for="question-module">Categorie</label>
-            <select id="question-module" required></select>
+            <label for="category-name">Naam</label>
+            <input id="category-name" type="text" required />
           </div>
           <div class="admin-field">
-            <label for="question-text">Vraag</label>
-            <textarea id="question-text" rows="3" required></textarea>
+            <label for="category-questions">Vragen per sessie</label>
+            <input id="category-questions" type="number" min="1" value="5" required />
           </div>
-          <div class="admin-field">
-            <label for="question-type">Type vraag</label>
-            <select id="question-type">
-              <option value="single">Meerkeuze (1 antwoord)</option>
-              <option value="multiple">Meerkeuze (meerdere antwoorden)</option>
-            </select>
-          </div>
-          <div class="admin-field">
-            <label>Antwoorden</label>
-            <div class="admin-options" id="options-list"></div>
-            <button type="button" class="admin-button admin-secondary" id="add-option">
-              Optie toevoegen
-            </button>
-          </div>
-          <div class="admin-field">
-            <label for="feedback-correct">Feedback bij goed antwoord</label>
-            <textarea id="feedback-correct" rows="2"></textarea>
-          </div>
-          <div class="admin-field">
-            <label for="feedback-incorrect">Feedback bij fout antwoord</label>
-            <textarea id="feedback-incorrect" rows="2"></textarea>
+          <div class="admin-field admin-field--inline">
+            <label class="admin-toggle">
+              <input id="category-active" type="checkbox" checked />
+              Actief in quiz
+            </label>
           </div>
           <div class="admin-actions">
             <button type="submit" class="admin-button">Opslaan</button>
-            <button type="button" class="admin-button admin-secondary" id="cancel-button">
+            <button
+              type="button"
+              class="admin-button admin-secondary"
+              id="category-cancel"
+              hidden
+            >
               Annuleren
             </button>
           </div>
@@ -77,6 +88,6 @@
       </section>
     </main>
     <script src="../src/adminMenu.js" defer></script>
-    <script src="../src/questionEditor.js" defer></script>
+    <script src="../src/adminCategories.js" defer></script>
   </body>
 </html>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4,13 +4,43 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Live quizdashboard</title>
+    <link rel="stylesheet" href="../styles/admin.css" />
     <link rel="stylesheet" href="../styles/digitalSafetyQuiz.css" />
   </head>
-  <body class="dsq-dashboard-page">
-    <div class="dsq-dashboard-wrapper">
-      <section id="dashboard" class="dsq-card"></section>
-    </div>
+  <body data-admin-page="dashboard">
+    <main class="admin-container">
+      <header class="admin-header">
+        <div class="admin-title-group">
+          <div class="admin-menu-wrapper">
+            <button
+              class="admin-menu-toggle"
+              type="button"
+              aria-label="Open navigatie"
+              aria-expanded="false"
+              aria-controls="admin-menu"
+            >
+              <span class="sr-only">Open navigatie</span>
+              <span class="admin-menu-bar"></span>
+              <span class="admin-menu-bar"></span>
+              <span class="admin-menu-bar"></span>
+            </button>
+            <nav class="admin-menu-dropdown" id="admin-menu" hidden>
+              <a class="admin-menu-link" href="database.html" data-page="database">Database</a>
+              <a class="admin-menu-link" href="categories.html" data-page="categories">Categorieën</a>
+              <a class="admin-menu-link" href="questions.html" data-page="questions">Vragen</a>
+              <a class="admin-menu-link" href="dashboard.html" data-page="dashboard">Live dashboard</a>
+            </nav>
+          </div>
+          <h1>Live quizdashboard</h1>
+        </div>
+      </header>
 
+      <section class="admin-card">
+        <div id="dashboard"></div>
+      </section>
+    </main>
+
+    <script src="../src/adminMenu.js" defer></script>
     <script src="../src/digitalSafetyQuiz.js"></script>
     <script src="../src/quizDashboard.js"></script>
     <script>

--- a/public/database.html
+++ b/public/database.html
@@ -4,19 +4,46 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Databaseoverzicht</title>
+    <link rel="stylesheet" href="../styles/admin.css" />
     <link rel="stylesheet" href="../styles/digitalSafetyQuiz.css" />
   </head>
-  <body class="dsq-dashboard-page">
-    <div class="dsq-dashboard-wrapper">
-      <section class="dsq-card">
-        <h1>Databaseoverzicht</h1>
+  <body data-admin-page="database">
+    <main class="admin-container">
+      <header class="admin-header">
+        <div class="admin-title-group">
+          <div class="admin-menu-wrapper">
+            <button
+              class="admin-menu-toggle"
+              type="button"
+              aria-label="Open navigatie"
+              aria-expanded="false"
+              aria-controls="admin-menu"
+            >
+              <span class="sr-only">Open navigatie</span>
+              <span class="admin-menu-bar"></span>
+              <span class="admin-menu-bar"></span>
+              <span class="admin-menu-bar"></span>
+            </button>
+            <nav class="admin-menu-dropdown" id="admin-menu" hidden>
+              <a class="admin-menu-link" href="database.html" data-page="database">Database</a>
+              <a class="admin-menu-link" href="categories.html" data-page="categories">Categorieën</a>
+              <a class="admin-menu-link" href="questions.html" data-page="questions">Vragen</a>
+              <a class="admin-menu-link" href="dashboard.html" data-page="dashboard">Live dashboard</a>
+            </nav>
+          </div>
+          <h1>Databaseoverzicht</h1>
+        </div>
+      </header>
+
+      <section class="admin-card">
         <p class="database-overview__intro">
           Hier zie je met welke database de applicatie verbonden is en hoeveel vragen er per categorie zijn opgeslagen.
         </p>
         <div id="database-overview" class="database-overview"></div>
       </section>
-    </div>
+    </main>
 
-    <script src="../src/databaseOverview.js"></script>
+    <script src="../src/adminMenu.js" defer></script>
+    <script src="../src/databaseOverview.js" defer></script>
   </body>
 </html>

--- a/public/questions.html
+++ b/public/questions.html
@@ -6,10 +6,32 @@
     <title>Vragenbeheer</title>
     <link rel="stylesheet" href="../styles/admin.css" />
   </head>
-  <body>
+  <body data-admin-page="questions">
     <main class="admin-container">
       <header class="admin-header">
-        <h1>Vragenbeheer</h1>
+        <div class="admin-title-group">
+          <div class="admin-menu-wrapper">
+            <button
+              class="admin-menu-toggle"
+              type="button"
+              aria-label="Open navigatie"
+              aria-expanded="false"
+              aria-controls="admin-menu"
+            >
+              <span class="sr-only">Open navigatie</span>
+              <span class="admin-menu-bar"></span>
+              <span class="admin-menu-bar"></span>
+              <span class="admin-menu-bar"></span>
+            </button>
+            <nav class="admin-menu-dropdown" id="admin-menu" hidden>
+              <a class="admin-menu-link" href="database.html" data-page="database">Database</a>
+              <a class="admin-menu-link" href="categories.html" data-page="categories">Categorieën</a>
+              <a class="admin-menu-link" href="questions.html" data-page="questions">Vragen</a>
+              <a class="admin-menu-link" href="dashboard.html" data-page="dashboard">Live dashboard</a>
+            </nav>
+          </div>
+          <h1>Vragenbeheer</h1>
+        </div>
         <a class="admin-button" href="question-editor.html">Nieuwe vraag</a>
       </header>
       <section class="admin-card" id="questions-card">
@@ -30,6 +52,7 @@
         </div>
       </section>
     </main>
+    <script src="../src/adminMenu.js" defer></script>
     <script src="../src/adminQuestions.js" defer></script>
   </body>
 </html>

--- a/src/adminCategories.js
+++ b/src/adminCategories.js
@@ -1,0 +1,392 @@
+(function () {
+  "use strict";
+
+  function $(selector) {
+    return document.querySelector(selector);
+  }
+
+  function createElement(tag, options = {}) {
+    const element = document.createElement(tag);
+    if (options.className) {
+      element.className = options.className;
+    }
+    if (options.text) {
+      element.textContent = options.text;
+    }
+    if (options.html) {
+      element.innerHTML = options.html;
+    }
+    if (options.attrs) {
+      Object.entries(options.attrs).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          element.setAttribute(key, value);
+        }
+      });
+    }
+    return element;
+  }
+
+  function showFeedback(container, message, variant = "error") {
+    if (!container) {
+      return;
+    }
+    container.innerHTML = "";
+    const box = createElement("div", {
+      className: variant === "error" ? "admin-error" : "admin-success",
+      text: message
+    });
+    container.append(box);
+  }
+
+  function clearFeedback(container) {
+    if (container) {
+      container.innerHTML = "";
+    }
+  }
+
+  function normalizeModule(module) {
+    if (!module) {
+      return null;
+    }
+    const questions = Number(module.questionsPerSession);
+    return {
+      id: module.id,
+      title: module.title || "Naamloze categorie",
+      questionsPerSession:
+        Number.isFinite(questions) && questions > 0 ? questions : 1,
+      isActive: Boolean(module.isActive)
+    };
+  }
+
+  async function fetchModules() {
+    const response = await fetch("/api/modules");
+    if (!response.ok) {
+      throw new Error("Kon categorieën niet laden");
+    }
+    const data = await response.json();
+    if (!Array.isArray(data)) {
+      return [];
+    }
+    return data
+      .map((module) => normalizeModule(module))
+      .filter((module) => module !== null);
+  }
+
+  async function createModule(payload) {
+    const response = await fetch("/api/modules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(
+        errorData.message || "Kon de categorie niet aanmaken"
+      );
+    }
+
+    const data = await response.json();
+    return normalizeModule(data);
+  }
+
+  async function updateModule(id, payload) {
+    const response = await fetch(`/api/modules/${encodeURIComponent(id)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || "Kon de categorie niet bijwerken");
+    }
+
+    const data = await response.json();
+    return normalizeModule(data);
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const table = document.getElementById("categories-table");
+    const tableBody = table ? table.querySelector("tbody") : null;
+    const emptyState = document.getElementById("categories-empty");
+    const listFeedback = document.getElementById("categories-feedback");
+    const newButton = document.getElementById("category-new");
+
+    const form = document.getElementById("category-form");
+    const formTitle = document.getElementById("category-form-title");
+    const nameInput = document.getElementById("category-name");
+    const questionsInput = document.getElementById("category-questions");
+    const activeInput = document.getElementById("category-active");
+    const formFeedback = document.getElementById("category-form-feedback");
+    const cancelButton = document.getElementById("category-cancel");
+    const submitButton = form ? form.querySelector("button[type='submit']") : null;
+
+    const state = {
+      modules: [],
+      editingId: null
+    };
+
+    function setEditing(module) {
+      if (!module) {
+        state.editingId = null;
+        if (formTitle) {
+          formTitle.textContent = "Nieuwe categorie";
+        }
+        if (nameInput) {
+          nameInput.value = "";
+        }
+        if (questionsInput) {
+          questionsInput.value = "5";
+        }
+        if (activeInput) {
+          activeInput.checked = true;
+        }
+        if (cancelButton) {
+          cancelButton.hidden = true;
+        }
+        return;
+      }
+
+      state.editingId = module.id;
+      if (formTitle) {
+        formTitle.textContent = "Categorie bewerken";
+      }
+      if (nameInput) {
+        nameInput.value = module.title || "";
+      }
+      if (questionsInput) {
+        questionsInput.value = String(module.questionsPerSession || 1);
+      }
+      if (activeInput) {
+        activeInput.checked = Boolean(module.isActive);
+      }
+      if (cancelButton) {
+        cancelButton.hidden = false;
+      }
+    }
+
+    function updateLocalModule(updated) {
+      const index = state.modules.findIndex((module) => module.id === updated.id);
+      if (index !== -1) {
+        state.modules[index] = updated;
+      } else {
+        state.modules.push(updated);
+      }
+    }
+
+    function renderModules() {
+      if (!table || !tableBody) {
+        return;
+      }
+
+      tableBody.innerHTML = "";
+
+      if (!state.modules.length) {
+        table.hidden = true;
+        if (emptyState) {
+          emptyState.hidden = false;
+        }
+        return;
+      }
+
+      table.hidden = false;
+      if (emptyState) {
+        emptyState.hidden = true;
+      }
+
+      state.modules.forEach((module) => {
+        const row = document.createElement("tr");
+
+        const nameCell = createElement("td");
+        const nameLabel = createElement("strong", { text: module.title });
+        nameCell.append(nameLabel);
+        if (!module.isActive) {
+          nameCell.append(" ");
+          nameCell.append(
+            createElement("span", {
+              className: "admin-tag admin-tag--muted",
+              text: "Inactief"
+            })
+          );
+        }
+
+        const questionsCell = createElement("td", {
+          text: String(module.questionsPerSession)
+        });
+
+        const statusCell = createElement("td");
+        const toggleLabel = createElement("label", {
+          className: "admin-toggle",
+          text: "Actief"
+        });
+        const toggle = createElement("input", {
+          attrs: { type: "checkbox" }
+        });
+        toggle.checked = Boolean(module.isActive);
+        toggle.addEventListener("change", () => {
+          const desired = toggle.checked;
+          toggle.disabled = true;
+          clearFeedback(listFeedback);
+          updateModule(module.id, {
+            title: module.title,
+            questionsPerSession: module.questionsPerSession,
+            isActive: desired
+          })
+            .then((updated) => {
+              updateLocalModule(updated);
+              renderModules();
+              showFeedback(
+                listFeedback,
+                `Categorie "${updated.title}" is ${
+                  updated.isActive ? "geactiveerd" : "gedeactiveerd"
+                }.`,
+                "success"
+              );
+            })
+            .catch((error) => {
+              toggle.checked = !desired;
+              showFeedback(
+                listFeedback,
+                error.message || "Kon de status niet bijwerken"
+              );
+            })
+            .finally(() => {
+              toggle.disabled = false;
+            });
+        });
+        toggleLabel.prepend(toggle);
+        statusCell.append(toggleLabel);
+
+        const actionCell = createElement("td");
+        const editButton = createElement("button", {
+          className: "admin-button admin-secondary",
+          text: "Bewerken",
+          attrs: { type: "button" }
+        });
+        editButton.addEventListener("click", () => {
+          setEditing(module);
+          clearFeedback(formFeedback);
+          if (nameInput) {
+            nameInput.focus();
+          }
+        });
+        actionCell.append(editButton);
+
+        row.append(nameCell, questionsCell, statusCell, actionCell);
+        tableBody.append(row);
+      });
+    }
+
+    function refreshModules() {
+      clearFeedback(listFeedback);
+      if (emptyState) {
+        emptyState.hidden = true;
+      }
+      if (table) {
+        table.hidden = true;
+      }
+
+      return fetchModules()
+        .then((modules) => {
+          state.modules = modules;
+          renderModules();
+        })
+        .catch((error) => {
+          showFeedback(
+            listFeedback,
+            error.message || "Kon categorieën niet laden"
+          );
+        });
+    }
+
+    if (cancelButton) {
+      cancelButton.addEventListener("click", () => {
+        clearFeedback(formFeedback);
+        setEditing(null);
+      });
+    }
+
+    if (newButton) {
+      newButton.addEventListener("click", () => {
+        clearFeedback(formFeedback);
+        setEditing(null);
+        if (nameInput) {
+          nameInput.focus();
+        }
+      });
+    }
+
+    if (form) {
+      form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        if (!submitButton) {
+          return;
+        }
+
+        const title = nameInput ? nameInput.value.trim() : "";
+        const questionsValue = questionsInput ? questionsInput.value : "";
+        const questionsPerSession = Number.parseInt(questionsValue, 10);
+        const isActive = activeInput ? activeInput.checked : true;
+
+        clearFeedback(formFeedback);
+
+        if (!title) {
+          showFeedback(formFeedback, "Vul een titel in");
+          return;
+        }
+
+        if (!Number.isFinite(questionsPerSession) || questionsPerSession <= 0) {
+          showFeedback(
+            formFeedback,
+            "Vul een positief aantal vragen per sessie in"
+          );
+          return;
+        }
+
+        submitButton.disabled = true;
+
+        const payload = {
+          title,
+          questionsPerSession,
+          isActive
+        };
+
+        const request = state.editingId
+          ? updateModule(state.editingId, payload)
+          : createModule(payload);
+
+        request
+          .then((module) => {
+            updateLocalModule(module);
+            renderModules();
+            showFeedback(
+              formFeedback,
+              state.editingId
+                ? "Categorie bijgewerkt"
+                : "Categorie toegevoegd",
+              "success"
+            );
+            if (!state.editingId) {
+              setEditing(null);
+            } else {
+              setEditing(module);
+            }
+            refreshModules();
+          })
+          .catch((error) => {
+            showFeedback(
+              formFeedback,
+              error.message || "Opslaan is mislukt"
+            );
+          })
+          .finally(() => {
+            submitButton.disabled = false;
+          });
+      });
+    }
+
+    setEditing(null);
+    refreshModules();
+  });
+})();

--- a/src/adminMenu.js
+++ b/src/adminMenu.js
@@ -1,0 +1,102 @@
+(function () {
+  "use strict";
+
+  function findMenu(toggle) {
+    const controlledId = toggle.getAttribute("aria-controls");
+    if (controlledId) {
+      const controlledMenu = document.getElementById(controlledId);
+      if (controlledMenu) {
+        return controlledMenu;
+      }
+    }
+
+    const sibling = toggle.nextElementSibling;
+    if (sibling && sibling.classList.contains("admin-menu-dropdown")) {
+      return sibling;
+    }
+
+    return null;
+  }
+
+  function highlightCurrent(menu) {
+    const currentPage = document.body?.dataset?.adminPage;
+    if (!currentPage) {
+      return;
+    }
+
+    const links = menu.querySelectorAll("[data-page]");
+    links.forEach((link) => {
+      if (link.dataset.page === currentPage) {
+        link.setAttribute("aria-current", "page");
+      } else {
+        link.removeAttribute("aria-current");
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const toggles = document.querySelectorAll(".admin-menu-toggle");
+    toggles.forEach((toggle) => {
+      const menu = findMenu(toggle);
+      if (!menu) {
+        return;
+      }
+
+      highlightCurrent(menu);
+      menu.setAttribute("role", "menu");
+      menu.querySelectorAll("a").forEach((link) => {
+        link.setAttribute("role", "menuitem");
+      });
+
+      const closeMenu = () => {
+        toggle.setAttribute("aria-expanded", "false");
+        menu.hidden = true;
+        document.removeEventListener("click", onDocumentClick);
+        document.removeEventListener("keydown", onKeyDown);
+      };
+
+      const openMenu = () => {
+        menu.hidden = false;
+        toggle.setAttribute("aria-expanded", "true");
+        setTimeout(() => {
+          document.addEventListener("click", onDocumentClick);
+        }, 0);
+        document.addEventListener("keydown", onKeyDown);
+      };
+
+      const onDocumentClick = (event) => {
+        if (
+          event.target !== toggle &&
+          !menu.contains(event.target)
+        ) {
+          closeMenu();
+        }
+      };
+
+      const onKeyDown = (event) => {
+        if (event.key === "Escape") {
+          closeMenu();
+          toggle.focus();
+        }
+      };
+
+      toggle.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const expanded = toggle.getAttribute("aria-expanded") === "true";
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      menu.addEventListener("click", (event) => {
+        const link = event.target?.closest?.(".admin-menu-link");
+        if (link) {
+          closeMenu();
+        }
+      });
+    });
+  });
+})();

--- a/src/questionEditor.js
+++ b/src/questionEditor.js
@@ -176,8 +176,11 @@
   function populateModules(select, modules, selectedId) {
     select.innerHTML = "";
     modules.forEach((module) => {
+      const label = module.isActive
+        ? module.title
+        : `${module.title} (inactief)`;
       const option = createElement("option", {
-        text: module.title,
+        text: label,
         attrs: { value: module.id }
       });
       if (selectedId && selectedId === module.id) {

--- a/styles/admin.css
+++ b/styles/admin.css
@@ -19,6 +19,80 @@ body {
   margin-bottom: 1.5rem;
 }
 
+.admin-title-group {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.admin-menu-wrapper {
+  position: relative;
+}
+
+.admin-menu-toggle {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 44px;
+  height: 44px;
+  background: #2563eb;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.admin-menu-toggle:hover,
+.admin-menu-toggle:focus-visible {
+  background: #1d4ed8;
+  outline: none;
+}
+
+.admin-menu-bar {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: #ffffff;
+  border-radius: 2px;
+}
+
+.admin-menu-bar + .admin-menu-bar {
+  margin-top: 4px;
+}
+
+.admin-menu-dropdown {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  min-width: 220px;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.15);
+  padding: 0.5rem 0;
+  z-index: 30;
+}
+
+.admin-menu-link {
+  display: block;
+  padding: 0.65rem 1rem;
+  color: #1f2937;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.admin-menu-link:hover,
+.admin-menu-link:focus-visible {
+  background: #f3f4f6;
+  color: #1d4ed8;
+  outline: none;
+}
+
+.admin-menu-link[aria-current="page"] {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
 .admin-card {
   background: #ffffff;
   border-radius: 12px;
@@ -81,6 +155,11 @@ body {
   font-weight: 600;
 }
 
+.admin-tag--muted {
+  background: #f3f4f6;
+  color: #4b5563;
+}
+
 .admin-form {
   display: grid;
   gap: 1rem;
@@ -90,6 +169,12 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.admin-field--inline {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .admin-field label {
@@ -134,6 +219,37 @@ body {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
+}
+
+.admin-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #374151;
+}
+
+.admin-table td .admin-tag {
+  margin-left: 0.5rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+#dashboard.dsq-dashboard {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
 }
 
 .admin-secondary {


### PR DESCRIPTION
## Summary
- add a dedicated admin page to list, create and edit categories with active toggles
- extend the backend to store the active flag, expose module CRUD endpoints and filter inactive categories from the quiz
- add a reusable hamburger navigation menu across admin pages and mark inactive categories in the question editor

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e296b4eec08323ae623bd2ce35e3c1