### PR TITLE
Fix question availability counts and add deletion controls

### DIFF
--- a/styles/admin.css
+++ b/styles/admin.css
@@ -261,9 +261,23 @@ body {
   border: 0;
 }
 
-.admin-secondary {
+.admin-button.admin-secondary {
   background: #f3f4f6;
   color: #1f2937;
+}
+
+.admin-button.admin-secondary:hover {
+  background: #e5e7eb;
+  color: #111827;
+}
+
+.admin-button.admin-danger {
+  background: #dc2626;
+  color: #ffffff;
+}
+
+.admin-button.admin-danger:hover {
+  background: #b91c1c;
 }
 
 .admin-error {


### PR DESCRIPTION
## Summary
- correct the module normalization and database overview query so the available question totals reflect active categories accurately
- add DELETE endpoints plus admin UI flows to remove categories (with cascading question cleanup) and individual questions after confirmation
- introduce a destructive button style and refresh admin tables after deletions

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68e2eb1107a483239b529f3e0c1ba389