### PR TITLE
Normalize questions-per-session handling

### DIFF
--- a/server/initializeDatabase.js
+++ b/server/initializeDatabase.js
@@ -287,6 +287,7 @@ async function getQuizConfig() {
     intro: module.intro,
     tips: JSON.parse(module.tips || "[]"),
     questionsPerSession: module.questions_per_session,
+    questions_per_session: module.questions_per_session,
     isActive: module.is_active === 1 || module.is_active === true,
     questionPool: questionMap[module.id] || []
   }));

--- a/src/adminCategories.js
+++ b/src/adminCategories.js
@@ -44,19 +44,37 @@
     }
   }
 
+  function resolveQuestionsPerSessionValue(source, fallback = 1) {
+    if (!source || typeof source !== "object") {
+      return fallback;
+    }
+
+    const candidates = [
+      source.questionsPerSession,
+      source.questions_per_session,
+      source.questions,
+      source.questionspersession
+    ];
+
+    for (const candidate of candidates) {
+      if (candidate === undefined || candidate === null || candidate === "") {
+        continue;
+      }
+
+      const numeric = Number(candidate);
+      if (Number.isFinite(numeric) && numeric > 0) {
+        return Math.floor(numeric);
+      }
+    }
+
+    return fallback;
+  }
+
   function normalizeModule(module) {
     if (!module) {
       return null;
     }
-    const rawQuestions =
-      module.questionsPerSession ??
-      module.questions_per_session ??
-      module.questions ??
-      null;
-    const questions = Number(rawQuestions);
-    const normalizedQuestions = Number.isFinite(questions) && questions > 0
-      ? Math.floor(questions)
-      : 1;
+    const normalizedQuestions = resolveQuestionsPerSessionValue(module, 1);
     return {
       id: module.id,
       title: module.title || "Naamloze categorie",

--- a/src/databaseOverview.js
+++ b/src/databaseOverview.js
@@ -41,16 +41,29 @@
   }
 
   function normalizeConfiguredQuestions(category) {
-    const rawConfigured =
-      category.questionsPerSession ??
-      category.questions_per_session ??
-      category.questionspersession ??
-      0;
-    const numericConfigured = Number(rawConfigured);
-    if (!Number.isFinite(numericConfigured) || numericConfigured <= 0) {
+    if (!category || typeof category !== "object") {
       return 0;
     }
-    return Math.floor(numericConfigured);
+
+    const candidates = [
+      category.questionsPerSession,
+      category.questions_per_session,
+      category.questions,
+      category.questionspersession
+    ];
+
+    for (const candidate of candidates) {
+      if (candidate === undefined || candidate === null || candidate === "") {
+        continue;
+      }
+
+      const numeric = Number(candidate);
+      if (Number.isFinite(numeric) && numeric > 0) {
+        return Math.floor(numeric);
+      }
+    }
+
+    return 0;
   }
 
   function renderCategories(container, categories, totalQuestions) {


### PR DESCRIPTION
## Summary
- normalize questions-per-session parsing in the admin UI and quiz runtime so legacy snake_case data is handled
- update the API to accept both camelCase and snake_case payloads and to expose a consistent questions_per_session field
- ensure exported quiz configuration retains both question count keys for compatibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2f0ee85e083238d40826042ca602b