### PR TITLE
Fix available question count on database overview

### DIFF
--- a/src/databaseOverview.js
+++ b/src/databaseOverview.js
@@ -33,9 +33,28 @@
       return 0;
     }
 
-    const numericCount = Number(category.questionCount);
-    if (Number.isFinite(numericCount) && numericCount >= 0) {
-      return numericCount;
+    const countCandidates = [
+      category.questionCount,
+      category.question_count,
+      category.questioncount,
+      category.questionsCount,
+      category.questions_count,
+      category.questionscount
+    ];
+
+    for (const candidate of countCandidates) {
+      if (candidate === undefined || candidate === null || candidate === "") {
+        continue;
+      }
+
+      const numericCount = Number(candidate);
+      if (Number.isFinite(numericCount) && numericCount >= 0) {
+        return numericCount;
+      }
+    }
+
+    if (Array.isArray(category.questionPool)) {
+      return category.questionPool.length;
     }
 
     if (Array.isArray(category.questions)) {


### PR DESCRIPTION
## Summary
- broaden normalization of category question totals so various field names are supported
- fall back to questionPool lengths when totals are missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4ab8f140083238bd75a10e6b124ec