### PR TITLE
Refactor admin pages to use shared UI helpers

### DIFF
--- a/public/categories.html
+++ b/public/categories.html
@@ -87,6 +87,7 @@
         </form>
       </section>
     </main>
+    <script src="../src/shared/adminUi.js" defer></script>
     <script src="../src/adminMenu.js" defer></script>
     <script src="../src/adminCategories.js" defer></script>
   </body>

--- a/public/database.html
+++ b/public/database.html
@@ -43,6 +43,7 @@
       </section>
     </main>
 
+    <script src="../src/shared/adminUi.js" defer></script>
     <script src="../src/adminMenu.js" defer></script>
     <script src="../src/databaseOverview.js" defer></script>
   </body>

--- a/public/question-editor.html
+++ b/public/question-editor.html
@@ -76,6 +76,7 @@
         </form>
       </section>
     </main>
+    <script src="../src/shared/adminUi.js" defer></script>
     <script src="../src/adminMenu.js" defer></script>
     <script src="../src/questionEditor.js" defer></script>
   </body>

--- a/public/questions.html
+++ b/public/questions.html
@@ -52,6 +52,7 @@
         </div>
       </section>
     </main>
+    <script src="../src/shared/adminUi.js" defer></script>
     <script src="../src/adminMenu.js" defer></script>
     <script src="../src/adminQuestions.js" defer></script>
   </body>

--- a/src/adminCategories.js
+++ b/src/adminCategories.js
@@ -5,62 +5,17 @@
     return document.querySelector(selector);
   }
 
-  function createElement(tag, options = {}) {
-    const element = document.createElement(tag);
-    if (options.className) {
-      element.className = options.className;
-    }
-    if (options.text) {
-      element.textContent = options.text;
-    }
-    if (options.html) {
-      element.innerHTML = options.html;
-    }
-    if (options.attrs) {
-      Object.entries(options.attrs).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) {
-          element.setAttribute(key, value);
-        }
-      });
-    }
-    return element;
-  }
+  const adminUI = (window.ChatSpel && window.ChatSpel.adminUI) || {};
+  const {
+    createElement,
+    createIcon,
+    showFeedback,
+    clearFeedback,
+    setListVisibility
+  } = adminUI;
 
-  const ICON_SVGS = {
-    edit:
-      '<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M15.232 5.232a2.5 2.5 0 0 0-3.536 0l-7.5 7.5a1 1 0 0 0-.263.465l-1 3.5a1 1 0 0 0 1.263 1.263l3.5-1a1 1 0 0 0 .465-.263l7.5-7.5a2.5 2.5 0 0 0 0-3.536l-1.5-1.5Zm-2.122 1.414 1.5 1.5-6.95 6.95-1.5-1.5 6.95-6.95Z"/><path d="M5.586 17H4a1 1 0 0 1-1-1v-1.586a1 1 0 0 1 .293-.707l2 2a1 1 0 0 1-.707.293Z"/></svg>',
-    delete:
-      '<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M7 4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2h3a1 1 0 1 1 0 2h-1v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6H3a1 1 0 1 1 0-2h4Zm6 2H7v11h6V6Zm-4 3a1 1 0 0 1 2 0v5a1 1 0 1 1-2 0V9Zm4 0a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V9Z"/></svg>'
-  };
-
-  function createIcon(type) {
-    const svg = ICON_SVGS[type];
-    if (!svg) {
-      return null;
-    }
-    const wrapper = document.createElement("span");
-    wrapper.className = "admin-button__icon";
-    wrapper.setAttribute("aria-hidden", "true");
-    wrapper.innerHTML = svg;
-    return wrapper;
-  }
-
-  function showFeedback(container, message, variant = "error") {
-    if (!container) {
-      return;
-    }
-    container.innerHTML = "";
-    const box = createElement("div", {
-      className: variant === "error" ? "admin-error" : "admin-success",
-      text: message
-    });
-    container.append(box);
-  }
-
-  function clearFeedback(container) {
-    if (container) {
-      container.innerHTML = "";
-    }
+  if (typeof createElement !== "function") {
+    throw new Error("Admin UI helpers zijn niet geladen");
   }
 
   function resolveQuestionsPerSessionValue(source, fallback = 1) {
@@ -242,17 +197,10 @@
 
       tableBody.innerHTML = "";
 
-      if (!state.modules.length) {
-        table.hidden = true;
-        if (emptyState) {
-          emptyState.hidden = false;
-        }
-        return;
-      }
+      setListVisibility(table, emptyState, state.modules);
 
-      table.hidden = false;
-      if (emptyState) {
-        emptyState.hidden = true;
+      if (!state.modules.length) {
+        return;
       }
 
       state.modules.forEach((module) => {

--- a/src/adminQuestions.js
+++ b/src/adminQuestions.js
@@ -1,44 +1,17 @@
 (function () {
   "use strict";
 
-  function createElement(tag, options = {}) {
-    const element = document.createElement(tag);
-    if (options.className) {
-      element.className = options.className;
-    }
-    if (options.text) {
-      element.textContent = options.text;
-    }
-    if (options.html) {
-      element.innerHTML = options.html;
-    }
-    if (options.attrs) {
-      Object.entries(options.attrs).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) {
-          element.setAttribute(key, value);
-        }
-      });
-    }
-    return element;
-  }
+  const adminUI = (window.ChatSpel && window.ChatSpel.adminUI) || {};
+  const {
+    createElement,
+    createIcon,
+    showFeedback,
+    clearFeedback,
+    setListVisibility
+  } = adminUI;
 
-  const ICON_SVGS = {
-    edit:
-      '<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M15.232 5.232a2.5 2.5 0 0 0-3.536 0l-7.5 7.5a1 1 0 0 0-.263.465l-1 3.5a1 1 0 0 0 1.263 1.263l3.5-1a1 1 0 0 0 .465-.263l7.5-7.5a2.5 2.5 0 0 0 0-3.536l-1.5-1.5Zm-2.122 1.414 1.5 1.5-6.95 6.95-1.5-1.5 6.95-6.95Z"/><path d="M5.586 17H4a1 1 0 0 1-1-1v-1.586a1 1 0 0 1 .293-.707l2 2a1 1 0 0 1-.707.293Z"/></svg>',
-    delete:
-      '<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M7 4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2h3a1 1 0 1 1 0 2h-1v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6H3a1 1 0 1 1 0-2h4Zm6 2H7v11h6V6Zm-4 3a1 1 0 0 1 2 0v5a1 1 0 1 1-2 0V9Zm4 0a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V9Z"/></svg>'
-  };
-
-  function createIcon(type) {
-    const svg = ICON_SVGS[type];
-    if (!svg) {
-      return null;
-    }
-    const wrapper = document.createElement("span");
-    wrapper.className = "admin-button__icon";
-    wrapper.setAttribute("aria-hidden", "true");
-    wrapper.innerHTML = svg;
-    return wrapper;
+  if (typeof createElement !== "function") {
+    throw new Error("Admin UI helpers zijn niet geladen");
   }
 
   function formatType(type) {
@@ -56,23 +29,6 @@
     return response.json();
   }
 
-  function showFeedback(container, message, variant = "error") {
-    if (!container) {
-      return;
-    }
-    container.innerHTML = "";
-    const box = createElement("div", {
-      className: variant === "error" ? "admin-error" : "admin-success",
-      text: message
-    });
-    container.append(box);
-  }
-
-  function clearFeedback(container) {
-    if (container) {
-      container.innerHTML = "";
-    }
-  }
 
   function resolveModuleTitle(question) {
     if (!question || typeof question !== "object") {
@@ -91,14 +47,11 @@
     const tbody = table.querySelector("tbody");
     tbody.innerHTML = "";
 
+    setListVisibility(table, emptyState, questions);
+
     if (!Array.isArray(questions) || !questions.length) {
-      table.hidden = true;
-      emptyState.hidden = false;
       return;
     }
-
-    emptyState.hidden = true;
-    table.hidden = false;
 
     questions.forEach((question) => {
       const row = document.createElement("tr");

--- a/src/databaseOverview.js
+++ b/src/databaseOverview.js
@@ -6,18 +6,11 @@
       ? new Intl.DateTimeFormat("nl-NL", { dateStyle: "long" })
       : null;
 
-  function createElement(tag, options = {}) {
-    const element = document.createElement(tag);
-    if (options.className) {
-      element.className = options.className;
-    }
-    if (options.text) {
-      element.textContent = options.text;
-    }
-    if (options.html) {
-      element.innerHTML = options.html;
-    }
-    return element;
+  const adminUI = (window.ChatSpel && window.ChatSpel.adminUI) || {};
+  const { createElement } = adminUI;
+
+  if (typeof createElement !== "function") {
+    throw new Error("Admin UI helpers zijn niet geladen");
   }
 
   async function fetchDatabaseInfo() {

--- a/src/questionEditor.js
+++ b/src/questionEditor.js
@@ -5,33 +5,11 @@
     return document.querySelector(selector);
   }
 
-  function createElement(tag, options = {}) {
-    const element = document.createElement(tag);
-    if (options.className) {
-      element.className = options.className;
-    }
-    if (options.text) {
-      element.textContent = options.text;
-    }
-    if (options.attrs) {
-      Object.entries(options.attrs).forEach(([key, value]) => {
-        element.setAttribute(key, value);
-      });
-    }
-    return element;
-  }
+  const adminUI = (window.ChatSpel && window.ChatSpel.adminUI) || {};
+  const { createElement, showFeedback, clearFeedback } = adminUI;
 
-  function showFeedback(container, message, variant = "error") {
-    container.innerHTML = "";
-    const box = createElement("div", {
-      className: variant === "error" ? "admin-error" : "admin-success",
-      text: message
-    });
-    container.append(box);
-  }
-
-  function clearFeedback(container) {
-    container.innerHTML = "";
+  if (typeof createElement !== "function") {
+    throw new Error("Admin UI helpers zijn niet geladen");
   }
 
   function getQueryParam(name) {

--- a/src/shared/adminUi.js
+++ b/src/shared/adminUi.js
@@ -1,0 +1,104 @@
+(function (global) {
+  "use strict";
+
+  function applyAttributes(element, attrs) {
+    if (!attrs) {
+      return;
+    }
+
+    Object.entries(attrs).forEach(([key, value]) => {
+      if (value === undefined || value === null) {
+        return;
+      }
+      element.setAttribute(key, value);
+    });
+  }
+
+  function createElement(tag, options = {}) {
+    const element = document.createElement(tag);
+
+    if (options.className) {
+      element.className = options.className;
+    }
+    if (options.text !== undefined) {
+      element.textContent = options.text;
+    }
+    if (options.html !== undefined) {
+      element.innerHTML = options.html;
+    }
+    applyAttributes(element, options.attrs);
+
+    return element;
+  }
+
+  const ICON_SVGS = {
+    edit:
+      '<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M15.232 5.232a2.5 2.5 0 0 0-3.536 0l-7.5 7.5a1 1 0 0 0-.263.465l-1 3.5a1 1 0 0 0 1.263 1.263l3.5-1a1 1 0 0 0 .465-.263l7.5-7.5a2.5 2.5 0 0 0 0-3.536l-1.5-1.5Zm-2.122 1.414 1.5 1.5-6.95 6.95-1.5-1.5 6.95-6.95Z"/><path d="M5.586 17H4a1 1 0 0 1-1-1v-1.586a1 1 0 0 1 .293-.707l2 2a1 1 0 0 1-.707.293Z"/></svg>',
+    delete:
+      '<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M7 4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2h3a1 1 0 1 1 0 2h-1v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6H3a1 1 0 1 1 0-2h4Zm6 2H7v11h6V6Zm-4 3a1 1 0 0 1 2 0v5a1 1 0 1 1-2 0V9Zm4 0a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V9Z"/></svg>'
+  };
+
+  function createIcon(type) {
+    const svg = ICON_SVGS[type];
+    if (!svg) {
+      return null;
+    }
+    const wrapper = document.createElement("span");
+    wrapper.className = "admin-button__icon";
+    wrapper.setAttribute("aria-hidden", "true");
+    wrapper.innerHTML = svg;
+    return wrapper;
+  }
+
+  function clearFeedback(container) {
+    if (container) {
+      container.innerHTML = "";
+    }
+  }
+
+  function showFeedback(container, message, variant = "error") {
+    if (!container) {
+      return;
+    }
+    clearFeedback(container);
+    const box = createElement("div", {
+      className: variant === "error" ? "admin-error" : "admin-success",
+      text: message
+    });
+    container.append(box);
+  }
+
+  function resolveHasItems(collection) {
+    if (Array.isArray(collection)) {
+      return collection.length > 0;
+    }
+    if (typeof collection === "number") {
+      return collection > 0;
+    }
+    return Boolean(collection);
+  }
+
+  function setListVisibility(table, emptyState, collection) {
+    const hasItems = resolveHasItems(collection);
+    if (table) {
+      table.hidden = !hasItems;
+    }
+    if (emptyState) {
+      emptyState.hidden = hasItems;
+    }
+  }
+
+  const adminUI = {
+    createElement,
+    createIcon,
+    showFeedback,
+    clearFeedback,
+    setListVisibility
+  };
+
+  if (!global.ChatSpel) {
+    global.ChatSpel = {};
+  }
+
+  global.ChatSpel.adminUI = adminUI;
+})(typeof window !== "undefined" ? window : globalThis);


### PR DESCRIPTION
## Summary
- add a shared admin UI helper module that centralises DOM creation, icons, and feedback handling
- refactor admin categories, questions, database overview, and question editor scripts to consume the shared helpers
- load the helper bundle on the relevant admin pages to keep behaviour consistent across views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8fd15bf488323b17403ab7fb01a92