### PR TITLE
Fix class creation form submission ordering

### DIFF
--- a/src/sessionGroupManager.js
+++ b/src/sessionGroupManager.js
@@ -184,12 +184,13 @@
       }
 
       showMessage(errorEl, "");
-      setFormDisabled(true);
 
       const formData = new FormData(form);
       const schoolName = String(formData.get("schoolName") || "").trim();
       const groupName = String(formData.get("groupName") || "").trim();
       const selectedModuleIds = getSelectedModuleIds(modulesContainer);
+
+      setFormDisabled(true);
 
       try {
         const createdGroup = await fetchJson("/api/session-groups", {


### PR DESCRIPTION
## Summary
- ensure the class creation form gathers the school and group names before disabling its inputs so they are sent with the request

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e916165d808323a275fe46eeb7292c