### PR TITLE
Improve class dashboard passkey visibility and sorting

### DIFF
--- a/src/sessionGroupManager.js
+++ b/src/sessionGroupManager.js
@@ -285,23 +285,52 @@
       }
     });
 
+    async function tryCopyToClipboard(text) {
+      if (!text) {
+        return false;
+      }
+
+      if (navigator.clipboard?.writeText) {
+        try {
+          await navigator.clipboard.writeText(text);
+          return true;
+        } catch (error) {
+          /* negeer en probeer fallback */
+        }
+      }
+
+      try {
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "absolute";
+        textarea.style.left = "-9999px";
+        document.body.append(textarea);
+        textarea.select();
+        const success = document.execCommand("copy");
+        textarea.remove();
+        return success;
+      } catch (error) {
+        return false;
+      }
+    }
+
     if (copyButton) {
       copyButton.addEventListener("click", async () => {
         const passKey = currentGroup?.passKey;
         if (!passKey) {
           return;
         }
-        try {
-          if (navigator.clipboard?.writeText) {
-            await navigator.clipboard.writeText(passKey);
-            copyButton.textContent = "Gekopieerd!";
-            window.setTimeout(() => {
-              copyButton.textContent = "Kopieer code";
-            }, 2500);
-          }
-        } catch (error) {
-          /* negeer kopieer fouten */
-        }
+
+        const originalLabel = copyButton.textContent;
+        copyButton.disabled = true;
+        const success = await tryCopyToClipboard(passKey);
+        copyButton.disabled = false;
+        copyButton.textContent = success ? "Gekopieerd!" : "Kopieer handmatig";
+
+        window.setTimeout(() => {
+          copyButton.textContent = originalLabel;
+        }, success ? 2000 : 3000);
       });
     }
   });

--- a/styles/admin.css
+++ b/styles/admin.css
@@ -496,9 +496,35 @@ body {
 }
 
 .session-dashboard-passkey {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
   margin: 0;
+}
+
+.session-dashboard-passkey-label {
   font-weight: 600;
   color: #1d4ed8;
+}
+
+.session-dashboard-passkey-value {
+  background: #0f172a;
+  color: #ffffff;
+  padding: 0.35rem 0.75rem;
+  border-radius: 10px;
+  letter-spacing: 0.25em;
+  font-size: 1.1rem;
+}
+
+.session-dashboard-passkey-copy {
+  font-size: 0.9rem;
+  padding: 0.35rem 0.75rem;
+}
+
+.session-dashboard-passkey-copy:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .session-dashboard-metrics {


### PR DESCRIPTION
## Summary
- show the class passkey at the top of the class dashboard with a copy button and clipboard fallback
- reuse the standard dashboard markup for active sessions and order them by most correct answers
- harden the class-code copy action on the session manager page with a non-secure-context fallback

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e9f7fae3a88323a2180f62d3215067